### PR TITLE
i2s_parallel implementation for esp32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `parl_io` Hub75 driver
+- `i2s_parallel` Hub75 driver for `esp32` (#5)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,12 @@ heapless = { version = "0.8.0", features = ["ufmt"] }
 
 [features]
 default = []
+esp32 = [
+    "esp-hal/esp32",
+    "esp-backtrace/esp32",
+    "esp-hal-embassy/esp32",
+    "esp-println/esp32",
+]
 esp32s3 = [
     "esp-hal/esp32s3",
     "esp-backtrace/esp32s3",
@@ -53,7 +59,11 @@ esp32c6 = [
     "esp-println/esp32c6",
 ]
 debug = ["esp-hal/debug"]
-defmt = ["dep:defmt", "esp-backtrace/defmt", "fugit/defmt"]
+defmt = [
+    "dep:defmt",
+    "esp-backtrace/defmt",
+    "fugit/defmt"
+]
 log = [
     "dep:log",
     "esp-backtrace/println",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ defmt = { version = "0.3.8", optional = true }
 embedded-graphics = { version = "0.8.1" }
 embedded-hal = { version = "1.0.0" }
 embedded-hal-async = { version = "1.0.0" }
-esp-hal = { version = "0.21.0" }
+esp-hal = { version = "0.21.1" }
 esp-hal-procmacros = { version = "0.14.0", features = ["ram"] }
 fugit = { version = "0.3.7" }
 log = { version = "0.4.22", optional = true }

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 Drive HUB75 displays from ESP32 series SOCs.
 
-**WARNING**: This is currently a very early WORK IN PROGRESS!
-
 All implementations use DMA where supported.
 
 - [ ] - documentation!
 - [x] - LCD peripheral  (async) for: `esp32s3`
   - [ ] - sync support for LCD peripheral
-- [ ] - I2S peripheral in LCD mode: `esp32`
+- [x] - I2S peripheral in LCD mode: `esp32`
 - [x] - PARL_IO peripheral: `esp32c6`
   - [ ] - sync support for PARL_IO peripheral
 
@@ -25,6 +23,11 @@ Will display  a red/green/blue gradient on the top 24 lines and some rendering a
 Expects a 64x64 matrix.
 
 ### [esp32c6: parl_io](examples/parl_io.rs)
+
+Will display  a red/green/blue gradient on the top 24 lines and some rendering and refresh stats at the bottom.
+Expects a 64x64 matrix.
+
+### [esp32: i2s](examples/i2s_parallel.rs)
 
 Will display  a red/green/blue gradient on the top 24 lines and some rendering and refresh stats at the bottom.
 Expects a 64x64 matrix.

--- a/build.rs
+++ b/build.rs
@@ -3,9 +3,22 @@ use esp_build::assert_unique_used_features;
 fn main() {
     // NOTE: update when adding new device support!
     // Ensure that exactly one chip has been specified:
-    assert_unique_used_features!("esp32c6", "esp32s3");
+    assert_unique_used_features!("esp32", "esp32c6", "esp32s3");
 
     let target = std::env::var("TARGET").unwrap();
+
+    #[cfg(feature = "esp32")]
+    {
+        #[cfg(feature = "valid-pin")]
+        compile_error!("feature 'valid-pin' is not supported on esp32");
+
+        assert!(
+            target == "xtensa-esp32-none-elf",
+            "feature esp32 does not match target {}",
+            target
+        );
+        println!("cargo:rustc-cfg=esp32");
+    }
 
     #[cfg(feature = "esp32s3")]
     {

--- a/examples/i2s_parallel.rs
+++ b/examples/i2s_parallel.rs
@@ -1,0 +1,393 @@
+//! Embassy "async" example driving a 64x64 HUB75 display using
+//! the I2S peripheral of an `esp32`.
+//!
+//! NOTE: This example would normally run on a second core, but the `esp32`
+//!       has a bug: https://github.com/esp-rs/esp-hal/issues/2369
+//!       and when thats resolved I'll move this back to the second core.
+//!
+//! This example draws a simple gradient on the display and shows the refresh
+//! rate and render rate plus a simple counter.
+//!
+//! Folowing pins are used:
+//! - R1  => GPIO16
+//! - G1  => GPIO4
+//! - B1  => GPIO17
+//! - R2  => GPIO18
+//! - G2  => GPIO19
+//! - B2  => GPIO5
+//! - A   => GPIO12
+//! - B   => GPIO14
+//! - C   => GPIO26
+//! - D   => GPIO27
+//! - E   => GPIO13
+//! - OE  => GPIO32
+//! - CLK => GPIO25
+//! - LAT => GPIO33
+//!
+//! Note that you most likeliy need level converters 3.3v to 5v for all HUB75
+//! signals
+#![no_std]
+#![no_main]
+#![feature(type_alias_impl_trait)]
+
+use core::fmt;
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::Ordering;
+
+#[cfg(feature = "defmt")]
+use defmt::info;
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+use embassy_executor::task;
+use embassy_executor::Spawner;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::signal::Signal;
+use embassy_time::Duration;
+use embassy_time::Instant;
+use embassy_time::Timer;
+use embedded_graphics::geometry::Point;
+use embedded_graphics::mono_font::ascii::FONT_5X7;
+use embedded_graphics::mono_font::MonoTextStyleBuilder;
+use embedded_graphics::pixelcolor::RgbColor;
+use embedded_graphics::text::Alignment;
+use embedded_graphics::text::Text;
+use embedded_graphics::Drawable;
+use esp_backtrace as _;
+use esp_hal::dma::Dma;
+use esp_hal::dma::DmaPriority;
+use esp_hal::dma::I2s0DmaChannelCreator;
+use esp_hal::gpio::AnyPin;
+use esp_hal::gpio::Io;
+use esp_hal::interrupt::software::SoftwareInterruptControl;
+use esp_hal::interrupt::Priority;
+use esp_hal::peripherals::I2S0;
+use esp_hal::prelude::*;
+use esp_hal::timer::timg::TimerGroup;
+use esp_hal_embassy::InterruptExecutor;
+use esp_hub75::framebuffer::compute_buffer_size;
+use esp_hub75::framebuffer::DmaFrameBuffer;
+use esp_hub75::framebuffer::Entry;
+use esp_hub75::i2s_parallel::Hub75;
+use esp_hub75::Color;
+use esp_hub75::Hub75Pins;
+use heapless::String;
+#[cfg(feature = "log")]
+use log::info;
+
+// When you are okay with using a nightly compiler it's better to use https://docs.rs/static_cell/2.1.0/static_cell/macro.make_static.html
+macro_rules! mk_static {
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write(($val));
+        x
+    }};
+}
+
+static REFRESH_RATE: AtomicU32 = AtomicU32::new(0);
+static RENDER_RATE: AtomicU32 = AtomicU32::new(0);
+static SIMPLE_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+const ROWS: usize = 64;
+const COLS: usize = 64;
+const BITS: u8 = 4;
+const SIZE: usize = compute_buffer_size(ROWS, COLS, BITS);
+
+type Hub75Type = Hub75<'static, esp_hal::Async>;
+type FBType = DmaFrameBuffer<ROWS, COLS, BITS, SIZE>;
+type FrameBufferExchange = Signal<CriticalSectionRawMutex, &'static mut FBType>;
+
+pub struct Hub75Peripherals {
+    pub i2s: I2S0,
+    pub dma_channel: I2s0DmaChannelCreator,
+    pub red1: AnyPin,
+    pub grn1: AnyPin,
+    pub blu1: AnyPin,
+    pub red2: AnyPin,
+    pub grn2: AnyPin,
+    pub blu2: AnyPin,
+    pub addr0: AnyPin,
+    pub addr1: AnyPin,
+    pub addr2: AnyPin,
+    pub addr3: AnyPin,
+    pub addr4: AnyPin,
+    pub blank: AnyPin,
+    pub clock: AnyPin,
+    pub latch: AnyPin,
+}
+
+#[task]
+async fn display_task(
+    rx: &'static FrameBufferExchange,
+    tx: &'static FrameBufferExchange,
+    mut fb: &'static mut FBType,
+) {
+    info!("display_task: starting!");
+    let fps_style = MonoTextStyleBuilder::new()
+        .font(&FONT_5X7)
+        .text_color(Color::YELLOW)
+        .background_color(Color::BLACK)
+        .build();
+    let mut count = 0u32;
+
+    let mut start = Instant::now();
+
+    loop {
+        fb.clear();
+
+        const STEP: u8 = (256 / COLS) as u8;
+        for x in 0..COLS {
+            let brightness = (x as u8) * STEP;
+            for y in 0..8 {
+                fb.set_pixel(Point::new(x as i32, y), Color::new(brightness, 0, 0));
+            }
+            for y in 8..16 {
+                fb.set_pixel(Point::new(x as i32, y), Color::new(0, brightness, 0));
+            }
+            for y in 16..24 {
+                fb.set_pixel(Point::new(x as i32, y), Color::new(0, 0, brightness));
+            }
+        }
+
+        let mut buffer: String<64> = String::new();
+
+        fmt::write(
+            &mut buffer,
+            format_args!("Refresh: {:4}", REFRESH_RATE.load(Ordering::Relaxed)),
+        )
+        .unwrap();
+        Text::with_alignment(
+            buffer.as_str(),
+            Point::new(0, 63),
+            fps_style,
+            Alignment::Left,
+        )
+        .draw(fb)
+        .unwrap();
+
+        buffer.clear();
+        fmt::write(
+            &mut buffer,
+            format_args!("Render: {:5}", RENDER_RATE.load(Ordering::Relaxed)),
+        )
+        .unwrap();
+
+        Text::with_alignment(
+            buffer.as_str(),
+            Point::new(0, 63 - 8),
+            fps_style,
+            Alignment::Left,
+        )
+        .draw(fb)
+        .unwrap();
+
+        buffer.clear();
+        fmt::write(
+            &mut buffer,
+            format_args!("Simple: {:5}", SIMPLE_COUNTER.load(Ordering::Relaxed)),
+        )
+        .unwrap();
+        Text::with_alignment(
+            buffer.as_str(),
+            Point::new(0, 63 - 16),
+            fps_style,
+            Alignment::Left,
+        )
+        .draw(fb)
+        .unwrap();
+
+        // send the frame buffer to be rendered
+        tx.signal(fb);
+
+        // get the next frame buffer
+        fb = rx.wait().await;
+
+        // count up the rate we are rendering full buffer
+        count += 1;
+        const FPS_INTERVAL: Duration = Duration::from_secs(1);
+        if start.elapsed() > FPS_INTERVAL {
+            RENDER_RATE.store(count, Ordering::Relaxed);
+            count = 0;
+            start = Instant::now();
+        }
+    }
+}
+
+#[task]
+async fn hub75_task(
+    peripherals: Hub75Peripherals,
+    rx: &'static FrameBufferExchange,
+    tx: &'static FrameBufferExchange,
+    fb: &'static mut FBType,
+) {
+    info!("hub75_task: starting!");
+    let channel = peripherals.dma_channel;
+    let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, SIZE * size_of::<Entry>());
+
+    let pins = Hub75Pins {
+        red1: peripherals.red1,
+        grn1: peripherals.grn1,
+        blu1: peripherals.blu1,
+        red2: peripherals.red2,
+        grn2: peripherals.grn2,
+        blu2: peripherals.blu2,
+        addr0: peripherals.addr0,
+        addr1: peripherals.addr1,
+        addr2: peripherals.addr2,
+        addr3: peripherals.addr3,
+        addr4: peripherals.addr4,
+        blank: peripherals.blank,
+        clock: peripherals.clock,
+        latch: peripherals.latch,
+    };
+
+    let mut hub75 = Hub75Type::new(
+        peripherals.i2s,
+        pins,
+        channel.configure_for_async(false, DmaPriority::Priority0),
+        tx_descriptors,
+        19.MHz(),
+    );
+
+    let mut count = 0u32;
+    let mut start = Instant::now();
+
+    // keep the frame buffer in an option so we can swap it
+    let mut fb = fb;
+
+    loop {
+        // if there is a new buffer available, get it and send the old one
+        if rx.signaled() {
+            let new_fb = rx.wait().await;
+            tx.signal(fb);
+            fb = new_fb;
+        }
+
+        hub75.render_async(fb).await;
+
+        count += 1;
+        const FPS_INTERVAL: Duration = Duration::from_secs(1);
+        if start.elapsed() > FPS_INTERVAL {
+            REFRESH_RATE.store(count, Ordering::Relaxed);
+            count = 0;
+            start = Instant::now();
+        }
+    }
+}
+
+extern "C" {
+    static _stack_end_cpu0: u32;
+    static _stack_start_cpu0: u32;
+}
+
+#[main]
+async fn main(spawner: Spawner) {
+    #[cfg(feature = "log")]
+    esp_println::logger::init_logger(log::LevelFilter::Info);
+    info!("Main starting!");
+    info!("main: stack size:  {}", unsafe {
+        core::ptr::addr_of!(_stack_start_cpu0).offset_from(core::ptr::addr_of!(_stack_end_cpu0))
+    });
+    info!("ROWS: {}", ROWS);
+    info!("COLS: {}", COLS);
+    info!("BITS: {}", BITS);
+    info!("SIZE: {}", SIZE);
+    let mut config = esp_hal::Config::default();
+    config.cpu_clock = CpuClock::max();
+    let peripherals = esp_hal::init(config);
+    let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    let software_interrupt = sw_ints.software_interrupt2;
+    let io = Io::new(peripherals.GPIO, peripherals.IO_MUX);
+    let dma = Dma::new(peripherals.DMA);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+
+    info!("init embassy");
+    esp_hal_embassy::init(timg0.timer0);
+
+    info!("init framebuffer exchange");
+    static TX: FrameBufferExchange = FrameBufferExchange::new();
+    static RX: FrameBufferExchange = FrameBufferExchange::new();
+
+    info!("init framebuffers");
+    let fb0 = mk_static!(FBType, FBType::new());
+    let fb1 = mk_static!(FBType, FBType::new());
+    fb0.clear();
+    fb1.clear();
+
+    info!("fb0: {:?}", fb0);
+    info!("fb1: {:?}", fb1);
+
+    let hub75_peripherals = Hub75Peripherals {
+        i2s: peripherals.I2S0,
+        dma_channel: dma.i2s0channel,
+        red1: io.pins.gpio16.degrade(),
+        grn1: io.pins.gpio4.degrade(),
+        blu1: io.pins.gpio17.degrade(),
+        red2: io.pins.gpio18.degrade(),
+        grn2: io.pins.gpio5.degrade(),
+        blu2: io.pins.gpio19.degrade(),
+        addr0: io.pins.gpio12.degrade(),
+        addr1: io.pins.gpio14.degrade(),
+        addr2: io.pins.gpio27.degrade(),
+        addr3: io.pins.gpio26.degrade(),
+        addr4: io.pins.gpio13.degrade(),
+        blank: io.pins.gpio32.degrade(),
+        clock: io.pins.gpio25.degrade(),
+        latch: io.pins.gpio33.degrade(),
+    };
+
+    let hp_executor = mk_static!(
+        InterruptExecutor<2>,
+        InterruptExecutor::new(software_interrupt)
+    );
+    let high_pri_spawner = hp_executor.start(Priority::Priority3);
+
+    // hub75 runs as high priority task
+    high_pri_spawner
+        .spawn(hub75_task(hub75_peripherals, &RX, &TX, fb1))
+        .ok();
+    spawner.spawn(display_task(&TX, &RX, fb0)).ok();
+
+    // // run hub75 and display on second core
+    // let cpu1_fnctn = {
+    //     move || {
+    //         let hp_executor = mk_static!(
+    //             InterruptExecutor<2>,
+    //             InterruptExecutor::new(software_interrupt)
+    //         );
+    //         let high_pri_spawner = hp_executor.start(Priority::Priority3);
+
+    //         // hub75 runs as high priority task
+    //         high_pri_spawner
+    //             .spawn(hub75_task(hub75_peripherals, &RX, &TX, fb1))
+    //             .ok();
+
+    //         let lp_executor = mk_static!(Executor, Executor::new());
+    //         // display task runs as low priority task
+    //         lp_executor.run(|spawner| {
+    //             spawner.spawn(display_task(&TX, &RX, fb0)).ok();
+    //         });
+    //     }
+    // };
+
+    // use esp_hal::cpu_control::CpuControl;
+    // use esp_hal::cpu_control::Stack;
+    // use esp_hal_embassy::Executor;
+    // let cpu_control = CpuControl::new(peripherals.CPU_CTRL);
+    // const DISPLAY_STACK_SIZE: usize = 8192;
+    // let app_core_stack = mk_static!(Stack<DISPLAY_STACK_SIZE>, Stack::new());
+    // let mut _cpu_control = cpu_control;
+
+    // #[allow(static_mut_refs)]
+    // let _guard = _cpu_control
+    //     .start_app_core(app_core_stack, cpu1_fnctn)
+    //     .unwrap();
+
+    loop {
+        if SIMPLE_COUNTER.fetch_add(1, Ordering::Relaxed) >= 99999 {
+            SIMPLE_COUNTER.store(0, Ordering::Relaxed);
+        }
+        Timer::after(Duration::from_millis(100)).await;
+    }
+}

--- a/examples/lcd_cam.rs
+++ b/examples/lcd_cam.rs
@@ -219,7 +219,9 @@ async fn hub75_task(
     fb: &'static mut FBType,
 ) {
     info!("hub75_task: starting!");
-    let channel = peripherals.dma_channel.configure_for_async(false, DmaPriority::Priority0);
+    let channel = peripherals
+        .dma_channel
+        .configure_for_async(false, DmaPriority::Priority0);
     let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, SIZE * size_of::<Entry>());
 
     let pins = Hub75Pins {
@@ -239,7 +241,8 @@ async fn hub75_task(
         latch: peripherals.latch,
     };
 
-    let mut hub75 = Hub75Type::new_async(peripherals.lcd_cam, pins, channel, tx_descriptors, 20.MHz());
+    let mut hub75 =
+        Hub75Type::new_async(peripherals.lcd_cam, pins, channel, tx_descriptors, 20.MHz());
 
     let mut count = 0u32;
     let mut start = Instant::now();

--- a/examples/parl_io.rs
+++ b/examples/parl_io.rs
@@ -212,7 +212,9 @@ async fn hub75_task(
     fb: &'static mut FBType,
 ) {
     info!("hub75_task: starting!");
-    let channel = peripherals.dma_channel.configure_for_async(false, DmaPriority::Priority0);
+    let channel = peripherals
+        .dma_channel
+        .configure_for_async(false, DmaPriority::Priority0);
     let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, SIZE * size_of::<Entry>());
 
     let pins = Hub75Pins {
@@ -232,7 +234,8 @@ async fn hub75_task(
         latch: peripherals.latch,
     };
 
-    let mut hub75 = Hub75Type::new_async(peripherals.parl_io, pins, channel, tx_descriptors, 15.MHz());
+    let mut hub75 =
+        Hub75Type::new_async(peripherals.parl_io, pins, channel, tx_descriptors, 15.MHz());
 
     let mut count = 0u32;
     let mut start = Instant::now();

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -117,6 +117,10 @@ impl<const ROWS: usize, const COLS: usize, const BITS: u8, const SIZE: usize>
                     entry.set_latch(true);
                     entry.set_addr(addr as u16);
                 }
+
+                #[cfg(feature = "esp32")]
+                let x = x ^ 1; // esp32 has words swapped!
+
                 buffer[start + x] = entry;
             }
             // next address
@@ -138,6 +142,9 @@ impl<const ROWS: usize, const COLS: usize, const BITS: u8, const SIZE: usize>
     }
 
     fn set_pixel_internal(&mut self, x: usize, y: usize, color: Rgb888) {
+        #[cfg(feature = "esp32")]
+        let x = x ^ 1; // esp32 has words swapped!
+
         if x >= COLS || y >= ROWS {
             return;
         }

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -64,7 +64,7 @@ pub const fn compute_frame_size(rows: usize, cols: usize) -> usize {
 }
 
 pub const fn compute_buffer_size(rows: usize, cols: usize, bits: u8) -> usize {
-    compute_frame_size(rows, cols) * (1 << (bits-1))
+    compute_frame_size(rows, cols) * (1 << (bits - 1))
 }
 
 impl<const ROWS: usize, const COLS: usize, const BITS: u8, const SIZE: usize>
@@ -75,7 +75,7 @@ impl<const ROWS: usize, const COLS: usize, const BITS: u8, const SIZE: usize>
         assert!(SIZE == compute_buffer_size(ROWS, COLS, BITS));
         Self {
             buffer: [Entry::new(); SIZE],
-            frame_count: 1usize << (BITS-1),
+            frame_count: 1usize << (BITS - 1),
             frame_size: compute_frame_size(ROWS, COLS),
             brightness_step: 1 << (8 - BITS),
         }

--- a/src/i2s_parallel.rs
+++ b/src/i2s_parallel.rs
@@ -1,9 +1,9 @@
 use core::cell::Cell;
 
 use esp_hal::dma::Channel;
-use esp_hal::dma::DmaEligible;
 use esp_hal::dma::DmaChannelConvert;
 use esp_hal::dma::DmaDescriptor;
+use esp_hal::dma::DmaEligible;
 use esp_hal::dma::DmaTxBuf;
 use esp_hal::gpio::NoPin;
 use esp_hal::i2s_parallel::I2sParallel;
@@ -93,6 +93,9 @@ impl<'d, DM: esp_hal::Mode> Hub75<'d, DM> {
         let i2s = I2sParallel::new(i2s, channel, frequency, pins, hub75_pins.clock);
         let i2s = Cell::new(Some(i2s));
         let tx_descriptors = Cell::new(Some(tx_descriptors));
-        Self { i2s, tx_descriptors }
+        Self {
+            i2s,
+            tx_descriptors,
+        }
     }
 }

--- a/src/i2s_parallel.rs
+++ b/src/i2s_parallel.rs
@@ -1,0 +1,98 @@
+use core::cell::Cell;
+
+use esp_hal::dma::Channel;
+use esp_hal::dma::DmaEligible;
+use esp_hal::dma::DmaChannelConvert;
+use esp_hal::dma::DmaDescriptor;
+use esp_hal::dma::DmaTxBuf;
+use esp_hal::gpio::NoPin;
+use esp_hal::i2s_parallel::I2sParallel;
+use esp_hal::i2s_parallel::TxSixteenBits;
+use esp_hal::peripherals::I2S0;
+
+use crate::framebuffer::DmaFrameBuffer;
+use crate::HertzU32;
+use crate::Hub75Pins;
+
+pub struct Hub75<'d, DM: esp_hal::Mode> {
+    i2s: Cell<Option<I2sParallel<'d, I2S0, DM>>>,
+    tx_descriptors: Cell<Option<&'static mut [DmaDescriptor]>>,
+}
+
+impl<'d> Hub75<'d, esp_hal::Async> {
+    // pub fn new_async(
+    //     i2s: I2S0,
+    //     hub75_pins: Hub75Pins,
+    //     channel: Channel<esp_hal::Async>,
+    //     tx_descriptors: &'static mut [DmaDescriptor],
+    //     frequency: HertzU32,
+    // ) -> Self {
+    //     let lcd_cam = I2sParallel::new(i2s);
+    //     Self::new_internal(i2s, hub75_pins, channel, tx_descriptors, frequency)
+    // }
+
+    pub async fn render_async<
+        const ROWS: usize,
+        const COLS: usize,
+        const BITS: u8,
+        const SIZE: usize,
+    >(
+        &mut self,
+        fb: &mut DmaFrameBuffer<ROWS, COLS, BITS, SIZE>,
+    ) {
+        let i2s = self.i2s.take().expect("i2s is None!");
+        let tx_descriptors = self.tx_descriptors.take().expect("tx_descriptors is None!");
+        let tx_buffer = unsafe {
+            use esp_hal::dma::ReadBuffer;
+            let (ptr, len) = fb.read_buffer();
+            // SAFETY: tx_buffer is only used until the tx_buf.split below!
+            core::slice::from_raw_parts_mut(ptr as *mut u8, len)
+        };
+        let tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).expect("DmaTxBuf::new failed");
+        let mut xfer = match i2s.send(tx_buf) {
+            Ok(xfer) => xfer,
+            Err(_) => {
+                panic!("Failed to send buffer");
+            }
+        };
+        xfer.wait_for_done().await.expect("transfer failed");
+        let (i2s, tx_buf) = xfer.wait();
+        let (tx_descriptors, _) = tx_buf.split();
+        self.i2s.set(Some(i2s));
+        self.tx_descriptors.set(Some(tx_descriptors));
+    }
+}
+
+impl<'d, DM: esp_hal::Mode> Hub75<'d, DM> {
+    pub fn new<CH: DmaChannelConvert<<esp_hal::peripherals::I2S0 as DmaEligible>::Dma>>(
+        i2s: I2S0,
+        hub75_pins: Hub75Pins,
+        channel: Channel<'d, CH, DM>,
+        tx_descriptors: &'static mut [DmaDescriptor],
+        frequency: HertzU32,
+    ) -> Self {
+        let pins = TxSixteenBits::new(
+            hub75_pins.addr0,
+            hub75_pins.addr1,
+            hub75_pins.addr2,
+            hub75_pins.addr3,
+            hub75_pins.addr4,
+            hub75_pins.latch,
+            NoPin,
+            NoPin,
+            hub75_pins.blank.into_peripheral_output().inverted(),
+            hub75_pins.red1,
+            hub75_pins.grn1,
+            hub75_pins.blu1,
+            hub75_pins.red2,
+            hub75_pins.grn2,
+            hub75_pins.blu2,
+            NoPin,
+        );
+
+        let i2s = I2sParallel::new(i2s, channel, frequency, pins, hub75_pins.clock);
+        let i2s = Cell::new(Some(i2s));
+        let tx_descriptors = Cell::new(Some(tx_descriptors));
+        Self { i2s, tx_descriptors }
+    }
+}

--- a/src/lcd_cam.rs
+++ b/src/lcd_cam.rs
@@ -2,8 +2,8 @@ use core::cell::Cell;
 
 use esp_hal::dma::Channel;
 use esp_hal::dma::DmaChannelConvert;
-use esp_hal::dma::DmaEligible;
 use esp_hal::dma::DmaDescriptor;
+use esp_hal::dma::DmaEligible;
 use esp_hal::dma::DmaTxBuf;
 use esp_hal::gpio::NoPin;
 use esp_hal::lcd_cam::lcd::i8080;
@@ -55,7 +55,9 @@ impl<'d> Hub75<'d, esp_hal::Async> {
             core::slice::from_raw_parts_mut(ptr as *mut u8, len)
         };
         let tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).expect("DmaTxBuf::new failed");
-        let mut xfer = i8080.send(Command::<u16>::None, 0, tx_buf).expect("send failed");
+        let mut xfer = i8080
+            .send(Command::<u16>::None, 0, tx_buf)
+            .expect("send failed");
         xfer.wait_for_done().await;
         let (result, i8080, tx_buf) = xfer.wait();
         result.expect("transfer failed");
@@ -105,6 +107,9 @@ impl<'d, DM: esp_hal::Mode> Hub75<'d, DM> {
         .with_ctrl_pins(NoPin, hub75_pins.clock);
         let i8080 = Cell::new(Some(i8080));
         let tx_descriptors = Cell::new(Some(tx_descriptors));
-        Self { i8080, tx_descriptors }
+        Self {
+            i8080,
+            tx_descriptors,
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,13 @@
 use embedded_graphics::pixelcolor::Rgb888;
 use esp_hal::gpio::AnyPin;
 
-#[cfg(any(feature = "esp32s3", feature = "esp32c6"))]
 pub mod framebuffer;
 #[cfg(feature = "esp32s3")]
 pub mod lcd_cam;
 #[cfg(feature = "esp32c6")]
 pub mod parl_io;
+#[cfg(feature = "esp32")]
+pub mod i2s_parallel;
 
 pub type Color = Rgb888;
 pub use fugit::HertzU32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@ use embedded_graphics::pixelcolor::Rgb888;
 use esp_hal::gpio::AnyPin;
 
 pub mod framebuffer;
+#[cfg(feature = "esp32")]
+pub mod i2s_parallel;
 #[cfg(feature = "esp32s3")]
 pub mod lcd_cam;
 #[cfg(feature = "esp32c6")]
 pub mod parl_io;
-#[cfg(feature = "esp32")]
-pub mod i2s_parallel;
 
 pub type Color = Rgb888;
 pub use fugit::HertzU32;

--- a/src/parl_io.rs
+++ b/src/parl_io.rs
@@ -1,7 +1,7 @@
 use esp_hal::dma::Channel;
 use esp_hal::dma::DmaChannelConvert;
-use esp_hal::dma::DmaEligible;
 use esp_hal::dma::DmaDescriptor;
+use esp_hal::dma::DmaEligible;
 use esp_hal::dma::ReadBuffer;
 use esp_hal::gpio::NoPin;
 use esp_hal::parl_io::BitPackOrder;
@@ -84,13 +84,7 @@ impl<'d> Hub75<'d, esp_hal::Async> {
         // TODO: how can we make this non-static?
         static CLOCK_PIN: StaticCell<ClkOutPin> = StaticCell::new();
         let clock_pin = CLOCK_PIN.init(ClkOutPin::new(hub75_pins.clock));
-        let parl_io = ParlIoTxOnly::new(
-            parl_io,
-            channel,
-            tx_descriptors,
-            frequency,
-        )
-        .unwrap(); // TODO: handle error
+        let parl_io = ParlIoTxOnly::new(parl_io, channel, tx_descriptors, frequency).unwrap(); // TODO: handle error
 
         let parl_io = parl_io
             .tx


### PR DESCRIPTION
This PR implements a Hub75 driver for `ESP32` using the `I2S` peripheral in parallel "lcd" mode.  It requires [this PR from esp-hal`](https://github.com/esp-rs/esp-hal/pull/2348).  Once its merged I'll merge this one.