### PR TITLE
i2s: add invert-clock feature (ESP32)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ embassy-futures = { version = "0.1.1" }
 embassy-sync = { version = "0.7.2" }
 embassy-time = { version = "0.5.0", features = [] }
 esp-backtrace = { version = "0.18.1", features = ["panic-handler"] }
-esp-hal = { version = "1.0.0", features = ["unstable"] }
 esp-println = { version = "0.16.1" }
 esp-rtos = { version = "0.2.0", features = ["embassy"] }
 heapless = { version = "0.8.0", features = ["ufmt"] }
@@ -54,6 +53,7 @@ iram = []
 esp32 = [
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
+    "esp-hal/rt",
     "esp-backtrace/esp32",
     "esp-rtos/esp32",
     "esp-println/esp32",
@@ -63,6 +63,7 @@ esp32 = [
 esp32s3 = [
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
+    "esp-hal/rt",
     "esp-backtrace/esp32s3",
     "esp-rtos/esp32s3",
     "esp-println/esp32s3",
@@ -71,6 +72,7 @@ esp32s3 = [
 esp32c6 = [
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
+    "esp-hal/rt",
     "esp-backtrace/esp32c6",
     "esp-rtos/esp32c6",
     "esp-println/esp32c6",
@@ -93,6 +95,7 @@ log = [
     "esp-println/colors",
 ]
 invert-blank = [] # only for some latched implementations
+invert-clock = []
 
 # this feature is required for the docs.rs build and release builds to work
 esp-hal-unstable = ["esp-hal/unstable"]
@@ -102,7 +105,10 @@ features = ["esp32c6", "esp-hal-unstable"]
 targets = ["riscv32imac-unknown-none-elf"]
 cargo-args = ["-Z", "build-std=core"]
 
-# [patch.crates-io]
+[patch.crates-io]
+# esp-rom-sys 0.1.3 fails to compile on ESP32 (Xtensa) with Rust 1.92+ due to an i8/to_ascii_lowercase issue.
+# The fix is merged on esp-hal's `main`, but not yet released on crates.io.
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
 
 # hub75-framebuffer = { path = "../hub75-framebuffer" }
 # hub75-framebuffer = { git = "https://github.com/liebman/hub75-framebuffer.git", branch = "main" }

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ tested and confirmed to work:
 |-------|-----------|------------|---------------|
 | Waveshare RGB-Matrix-P3-64x64 | 1/32 | SM5166 | SM16208 |
 | Waveshare RGB-Matrix-P3-64x32 | 1/16 | SM5166 | ICN2037 |
+| Waveshare RGB-Matrix-P2.5-96x48 | 1/24 | SM5166 | ICN2037BP |
 
 **Note**: Help us grow this list! Please let us know of other working and non working panels/chips.
 

--- a/examples/checkerboard_i2s_parallel.rs
+++ b/examples/checkerboard_i2s_parallel.rs
@@ -1,0 +1,152 @@
+//! Diagnostic checkerboard example for HUB75 panels (I2S-parallel).
+//!
+//! This example renders a filled checkerboard pattern to help diagnose column
+//! ordering, bit alignment, and clock-edge sampling issues.
+//!
+//! It is especially useful for panels that appear to work with animations but
+//! show distortion on static vertical or horizontal features.
+//!
+//! ## Running the example
+//!
+//! ```bash
+//! cargo +esp run --release \
+//!   --example checkerboard_i2s_parallel \
+//!   --features esp32,log,esp-hal-unstable,invert-clock
+//! ```
+//! 
+//! Disable `invert-clock` if your panel does not require inverted CLK sampling.
+
+#![no_std]
+#![no_main]
+#![allow(clippy::uninlined_format_args)]
+
+#[cfg(feature = "defmt")]
+use defmt_rtt as _;
+use embedded_graphics::geometry::Point;
+use embedded_graphics::geometry::Size;
+use embedded_graphics::primitives::{PrimitiveStyleBuilder, Rectangle};
+use embedded_graphics::prelude::{Primitive, RgbColor};
+use embedded_graphics::Drawable;
+use esp_backtrace as _;
+use esp_hal::clock::CpuClock;
+use esp_hal::gpio::Pin;
+use esp_hal::main;
+use esp_hal::time::Rate;
+use esp_hub75::framebuffer::compute_frame_count;
+use esp_hub75::framebuffer::compute_rows;
+use esp_hub75::framebuffer::plain::DmaFrameBuffer;
+use esp_hub75::Color;
+use esp_hub75::Hub75;
+use esp_hub75::Hub75Pins16;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+// Panel geometry
+const ROWS: usize = 48;
+const COLS: usize = 96;
+
+// Color depth
+const BITS: u8 = 1;
+
+// Diagnostic checkerboard parameters
+//
+// We draw a checkerboard of filled squares (not lines) so row 0 and col 0 are
+// part of a cell rather than being a "border line".
+const GRID_SIZE: i32 = 8;
+
+// Set to `-(GRID_SIZE / 2)` to start half a cell "before" (0, 0) so the first
+// boundary falls at GRID_SIZE/2. This can help reveal sampling-edge issues.
+const GRID_ORIGIN: i32 = 0;
+
+const NROWS: usize = compute_rows(ROWS);
+const FRAME_COUNT: usize = compute_frame_count(BITS);
+
+type FBType = DmaFrameBuffer<ROWS, COLS, NROWS, BITS, FRAME_COUNT>;
+
+#[main]
+fn main() -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    let (_, tx_descriptors) = esp_hal::dma_descriptors!(0, FBType::dma_buffer_size_bytes());
+
+    // TIP:
+    // If you see column misalignment or horizontal distortion on some panels,
+    // try building with the `invert-clock` feature enabled.
+    let pins = Hub75Pins16 {
+        red1: peripherals.GPIO25.degrade(),
+        grn1: peripherals.GPIO26.degrade(),
+        blu1: peripherals.GPIO27.degrade(),
+        red2: peripherals.GPIO14.degrade(),
+        grn2: peripherals.GPIO12.degrade(),
+        blu2: peripherals.GPIO13.degrade(),
+        addr0: peripherals.GPIO23.degrade(),
+        addr1: peripherals.GPIO19.degrade(),
+        addr2: peripherals.GPIO5.degrade(),
+        addr3: peripherals.GPIO17.degrade(),
+        addr4: peripherals.GPIO32.degrade(),
+        blank: peripherals.GPIO15.degrade(),
+        clock: peripherals.GPIO16.degrade(),
+        latch: peripherals.GPIO4.degrade(),
+    };
+
+    let mut hub75 = Hub75::new(
+        peripherals.I2S0.into(),
+        pins,
+        peripherals.DMA_I2S0,
+        tx_descriptors,
+        Rate::from_mhz(5),
+    )
+    .expect("failed to create Hub75!")
+    .into_async();
+
+    let mut fb = FBType::new();
+
+    // Fill background
+    let bg = PrimitiveStyleBuilder::new()
+        .fill_color(Color::BLACK)
+        .build();
+    Rectangle::new(Point::new(0, 0), Size::new(COLS as u32, ROWS as u32))
+        .into_styled(bg)
+        .draw(&mut fb)
+        .expect("failed to clear framebuffer");
+
+    // Draw a checkerboard of GRID_SIZE x GRID_SIZE filled squares (not lines)
+    // to diagnose bit/byte ordering and sampling-edge issues.
+    let cell_on = PrimitiveStyleBuilder::new()
+        .fill_color(Color::WHITE)
+        .build();
+
+    // Iterate cells starting at GRID_ORIGIN so the first boundary is at GRID_SIZE/2.
+    // Negative coordinates are OK; drawing will be clipped to the framebuffer.
+    let mut y = GRID_ORIGIN;
+    let mut y_idx: i32 = 0;
+    while y < ROWS as i32 {
+        let mut x = GRID_ORIGIN;
+        let mut x_idx: i32 = 0;
+        while x < COLS as i32 {
+            let is_white = ((x_idx + y_idx) & 1) == 0;
+            if is_white {
+                Rectangle::new(
+                    Point::new(x, y),
+                    Size::new(GRID_SIZE as u32, GRID_SIZE as u32),
+                )
+                .into_styled(cell_on)
+                .draw(&mut fb)
+                .expect("failed to draw checkerboard cell");
+            }
+            x += GRID_SIZE;
+            x_idx += 1;
+        }
+        y += GRID_SIZE;
+        y_idx += 1;
+    }
+    loop {
+        let xfer = hub75
+            .render(&fb)
+            .map_err(|(e, _hub75)| e)
+            .expect("failed to start render!");
+        let (result, new_hub75) = xfer.wait();
+        hub75 = new_hub75;
+        result.expect("transfer failed");
+    }
+}

--- a/src/i2s_parallel.rs
+++ b/src/i2s_parallel.rs
@@ -2,8 +2,8 @@ use esp_hal::dma::DmaChannelFor;
 use esp_hal::dma::DmaDescriptor;
 use esp_hal::dma::DmaError;
 use esp_hal::dma::DmaTxBuf;
-use esp_hal::gpio::AnyPin;
 use esp_hal::gpio::NoPin;
+use esp_hal::gpio::interconnect::OutputSignal;
 use esp_hal::i2s::parallel::I2sParallel;
 use esp_hal::i2s::parallel::I2sParallelTransfer;
 use esp_hal::i2s::parallel::TxEightBits;
@@ -16,11 +16,34 @@ use esp_hal::ram;
 
 use crate::framebuffer::FrameBuffer;
 use crate::Hub75Error;
-use crate::Hub75Pins;
 use crate::Hub75Pins16;
 use crate::Hub75Pins8;
 
-/// HUB75 LED matrix display driver using I2S Parallel
+/// Sealed trait pattern to restrict implementations of `Hub75PinsI2s`.
+mod private {
+    pub trait Sealed {}
+
+    impl<'d> Sealed for crate::Hub75Pins16<'d> {}
+    impl<'d> Sealed for crate::Hub75Pins8<'d> {}
+}
+
+/// ESP32 (I2S-parallel) backend-local pin conversion.
+///
+/// This trait is intentionally local to the ESP32 backend so we can implement
+/// clock inversion ("clkphase"-style) without changing the public pin trait in
+/// `src/lib.rs`.
+///
+/// This ensures `Hub75::new(...)` can apply the correct clock handling for
+/// `Hub75Pins16` while leaving the external-latch (`Hub75Pins8`) path unchanged.
+#[doc(hidden)]
+pub trait Hub75PinsI2s<'d, T: TxPins<'d>>: private::Sealed {
+    /// Converts the high-level pin definition into the peripheral-specific format for I2S-parallel.
+    ///
+    /// Returns the I2S-parallel transmit bundle and the typed CLK output signal.
+    fn convert_pins_i2s(self) -> (T, OutputSignal<'d>);
+}
+
+/// HUB75 LED matrix display driver using I2S Parallel.
 ///
 /// This driver uses the ESP32's I2S peripheral in parallel mode to drive HUB75
 /// LED matrix displays. It supports both 8-bit and 16-bit configurations and
@@ -31,28 +54,22 @@ pub struct Hub75<'d, DM: esp_hal::DriverMode> {
 }
 
 impl<'d> Hub75<'d, esp_hal::Blocking> {
-    /// Creates a new blocking HUB75 driver instance
+    /// Creates a new blocking HUB75 driver instance.
     ///
-    /// # Arguments
-    /// * `i2s` - The I2S peripheral instance
-    /// * `hub75_pins` - The HUB75 pin configuration
-    /// * `channel` - The DMA channel to use for transfers
-    /// * `tx_descriptors` - DMA descriptors for the transfer buffer
-    /// * `frequency` - The clock frequency for the display
+    /// The concrete pin configuration is selected by the `hub75_pins` argument.
+    /// For example, use `Hub75Pins16` for direct-address panels or `Hub75Pins8`
+    /// when an external address latch is used.
     ///
-    /// # Returns
-    /// A new `Hub75` instance configured for blocking operation
-    ///
-    /// # Errors
-    /// Returns an error if the peripheral cannot be configured
+    /// When the `invert-clock` feature is enabled, the 16-bit (`Hub75Pins16`) path
+    /// inverts the HUB75 CLK signal (equivalent to a "clkphase" switch in other drivers).
     pub fn new<T: TxPins<'d>>(
         i2s: AnyI2s<'d>,
-        hub75_pins: impl Hub75Pins<'d, T>,
+        hub75_pins: impl Hub75PinsI2s<'d, T>,
         channel: impl DmaChannelFor<AnyI2s<'d>>,
         tx_descriptors: &'static mut [DmaDescriptor],
         frequency: Rate,
     ) -> Result<Self, Hub75Error> {
-        let (pins, clock) = hub75_pins.convert_pins();
+        let (pins, clock) = hub75_pins.convert_pins_i2s();
         let i2s = I2sParallel::new(i2s, channel, frequency, pins, clock);
         Ok(Self {
             i2s,
@@ -60,7 +77,7 @@ impl<'d> Hub75<'d, esp_hal::Blocking> {
         })
     }
 
-    /// Converts this blocking instance into an async instance
+    /// Converts this blocking instance into an async instance.
     pub fn into_async(self) -> Hub75<'d, esp_hal::Async> {
         Hub75 {
             i2s: self.i2s.into_async(),
@@ -70,23 +87,9 @@ impl<'d> Hub75<'d, esp_hal::Blocking> {
 }
 
 impl<'d, DM: esp_hal::DriverMode> Hub75<'d, DM> {
-    /// Renders a frame buffer to the display.
+    /// Starts a DMA transfer that renders the provided framebuffer.
     ///
-    /// Calling render consumes the `Hub75` instance and returns a
-    /// `Hub75Transfer` instance that can be used to wait for the transfer
-    /// to complete.  After the transfer is complete, the `Hub75` will be
-    /// returned from the `wait()` method on the `Hub75Transfer` instance.
-    ///
-    /// # Arguments
-    /// * `fb` - The frame buffer to render
-    ///
-    /// # Returns
-    /// A `Hub75Transfer` instance that can be used to wait for the transfer to
-    /// complete
-    ///
-    /// # Errors
-    /// Returns a tuple of `Hub75Error` and the `Hub75` instance if the transfer
-    /// cannot be started
+    /// This consumes `self` and returns a `Hub75Transfer` that can be waited on.
     #[cfg_attr(feature = "iram", ram)]
     pub fn render<
         const ROWS: usize,
@@ -102,10 +105,8 @@ impl<'d, DM: esp_hal::DriverMode> Hub75<'d, DM> {
         let tx_descriptors = self.tx_descriptors;
         let tx_buffer = unsafe {
             let (ptr, len) = fb.read_buffer();
-            // SAFETY: tx_buffer is only used until the tx_buf.split below!
             core::slice::from_raw_parts_mut(ptr as *mut u8, len)
         };
-        // TODO: can't recover from this because tx_descriptors is consumed!
         let tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).expect("DmaTxBuf::new failed");
         let xfer = i2s.send(tx_buf).map_err(|(e, i2s, buf)| {
             let (tx_descriptors, _) = buf.split();
@@ -121,34 +122,21 @@ impl<'d, DM: esp_hal::DriverMode> Hub75<'d, DM> {
     }
 }
 
-/// Represents an in-progress transfer to the HUB75 display
+/// Represents an in-progress transfer to the HUB75 display.
 ///
-/// This struct is returned by `Hub75::render` and can be used to wait for the
-/// transfer to complete. It provides both blocking and async methods for
-/// waiting.
+/// This is returned by `Hub75::render`.
 pub struct Hub75Transfer<'d, DM: esp_hal::DriverMode> {
     xfer: I2sParallelTransfer<'d, DmaTxBuf, DM>,
 }
 
 impl<'d, DM: esp_hal::DriverMode> Hub75Transfer<'d, DM> {
-    /// Checks if the transfer is complete
-    ///
-    /// # Returns
-    /// `true` if the transfer is complete and `wait()` will not block
+    /// Returns `true` if the DMA transfer has completed.
     #[cfg_attr(feature = "iram", ram)]
     pub fn is_done(&self) -> bool {
         self.xfer.is_done()
     }
 
-    /// Waits for the transfer to complete
-    ///
-    /// # Returns
-    /// A tuple containing:
-    /// 1. The result of the transfer
-    /// 2. The `Hub75` instance for reuse
-    ///
-    /// # Note
-    /// This method clears the transfer interrupt flag
+    /// Blocks until the DMA transfer completes and returns the driver for reuse.
     #[cfg_attr(feature = "iram", ram)]
     pub fn wait(self) -> (Result<(), DmaError>, Hub75<'d, DM>) {
         let (i2s, tx_buf) = self.xfer.wait();
@@ -164,23 +152,17 @@ impl<'d, DM: esp_hal::DriverMode> Hub75Transfer<'d, DM> {
 }
 
 impl Hub75Transfer<'_, esp_hal::Async> {
-    /// Asynchronously waits for the transfer to complete
-    ///
-    /// # Returns
-    /// A `Result` indicating whether the transfer completed successfully
-    ///
-    /// # Note
-    /// This method does not return the `Hub75` instance. Use `wait()` after
-    /// `wait_for_done` returns to get the `Hub75` instance, it won't block at
-    /// that point.
+    /// Asynchronously waits for the DMA transfer to complete.
     #[cfg_attr(feature = "iram", ram)]
     pub async fn wait_for_done(&mut self) -> Result<(), DmaError> {
         self.xfer.wait_for_done().await
     }
 }
 
-impl<'d> crate::Hub75Pins<'d, TxSixteenBits<'d>> for Hub75Pins16<'d> {
-    fn convert_pins(self) -> (TxSixteenBits<'d>, AnyPin<'d>) {
+/// I2S-parallel pin conversion for a 16-bit (direct-address) HUB75 wiring.
+impl<'d> Hub75PinsI2s<'d, TxSixteenBits<'d>> for Hub75Pins16<'d> {
+    /// Converts the pins into the I2S-parallel transmit bundle and the CLK output signal.
+    fn convert_pins_i2s(self) -> (TxSixteenBits<'d>, OutputSignal<'d>) {
         let (_, blank) = unsafe { self.blank.split() };
         let pins = TxSixteenBits::new(
             self.addr0,
@@ -191,6 +173,7 @@ impl<'d> crate::Hub75Pins<'d, TxSixteenBits<'d>> for Hub75Pins16<'d> {
             self.latch,
             NoPin,
             NoPin,
+            // Keep existing blank inversion behaviour for 16-bit panels.
             blank.with_output_inverter(true),
             self.red1,
             self.grn1,
@@ -200,12 +183,27 @@ impl<'d> crate::Hub75Pins<'d, TxSixteenBits<'d>> for Hub75Pins16<'d> {
             self.blu2,
             NoPin,
         );
-        (pins, self.clock)
+
+        let (_, clock) = unsafe { self.clock.split() };
+        let clock = {
+            #[cfg(feature = "invert-clock")]
+            {
+                clock.with_output_inverter(true)
+            }
+            #[cfg(not(feature = "invert-clock"))]
+            {
+                clock
+            }
+        };
+
+        (pins, clock)
     }
 }
 
-impl<'d> crate::Hub75Pins<'d, TxEightBits<'d>> for Hub75Pins8<'d> {
-    fn convert_pins(self) -> (TxEightBits<'d>, AnyPin<'d>) {
+/// I2S-parallel pin conversion for an 8-bit HUB75 wiring with an external address latch.
+impl<'d> Hub75PinsI2s<'d, TxEightBits<'d>> for Hub75Pins8<'d> {
+    /// Converts the pins into the I2S-parallel transmit bundle and the CLK output signal.
+    fn convert_pins_i2s(self) -> (TxEightBits<'d>, OutputSignal<'d>) {
         let (_, blank) = unsafe { self.blank.split() };
         let pins = TxEightBits::new(
             self.red1,
@@ -220,6 +218,9 @@ impl<'d> crate::Hub75Pins<'d, TxEightBits<'d>> for Hub75Pins8<'d> {
             #[cfg(not(feature = "invert-blank"))]
             blank,
         );
-        (pins, self.clock)
+
+        // IMPORTANT: do NOT apply clock inversion on the external-latch (8-bit) path.
+        let (_, clock) = unsafe { self.clock.split() };
+        (pins, clock)
     }
 }

--- a/src/i2s_parallel.rs
+++ b/src/i2s_parallel.rs
@@ -54,11 +54,20 @@ pub struct Hub75<'d, DM: esp_hal::DriverMode> {
 }
 
 impl<'d> Hub75<'d, esp_hal::Blocking> {
-    /// Creates a new blocking HUB75 driver instance.
+    /// Creates a new blocking HUB75 driver instance
     ///
-    /// The concrete pin configuration is selected by the `hub75_pins` argument.
-    /// For example, use `Hub75Pins16` for direct-address panels or `Hub75Pins8`
-    /// when an external address latch is used.
+    /// # Arguments
+    /// * `i2s` - The I2S peripheral instance
+    /// * `hub75_pins` - The HUB75 pin configuration
+    /// * `channel` - The DMA channel to use for transfers
+    /// * `tx_descriptors` - DMA descriptors for the transfer buffer
+    /// * `frequency` - The clock frequency for the display
+    ///
+    /// # Returns
+    /// A new `Hub75` instance configured for blocking operation
+    ///
+    /// # Errors
+    /// Returns an error if the peripheral cannot be configured
     ///
     /// When the `invert-clock` feature is enabled, the 16-bit (`Hub75Pins16`) path
     /// inverts the HUB75 CLK signal (equivalent to a "clkphase" switch in other drivers).
@@ -87,9 +96,23 @@ impl<'d> Hub75<'d, esp_hal::Blocking> {
 }
 
 impl<'d, DM: esp_hal::DriverMode> Hub75<'d, DM> {
-    /// Starts a DMA transfer that renders the provided framebuffer.
+    /// Renders a frame buffer to the display.
     ///
-    /// This consumes `self` and returns a `Hub75Transfer` that can be waited on.
+    /// Calling render consumes the `Hub75` instance and returns a
+    /// `Hub75Transfer` instance that can be used to wait for the transfer
+    /// to complete.  After the transfer is complete, the `Hub75` will be
+    /// returned from the `wait()` method on the `Hub75Transfer` instance.
+    ///
+    /// # Arguments
+    /// * `fb` - The frame buffer to render
+    ///
+    /// # Returns
+    /// A `Hub75Transfer` instance that can be used to wait for the transfer to
+    /// complete
+    ///
+    /// # Errors
+    /// Returns a tuple of `Hub75Error` and the `Hub75` instance if the transfer
+    /// cannot be started
     #[cfg_attr(feature = "iram", ram)]
     pub fn render<
         const ROWS: usize,
@@ -122,21 +145,34 @@ impl<'d, DM: esp_hal::DriverMode> Hub75<'d, DM> {
     }
 }
 
-/// Represents an in-progress transfer to the HUB75 display.
+/// Represents an in-progress transfer to the HUB75 display
 ///
-/// This is returned by `Hub75::render`.
+/// This struct is returned by `Hub75::render` and can be used to wait for the
+/// transfer to complete. It provides both blocking and async methods for
+/// waiting.
 pub struct Hub75Transfer<'d, DM: esp_hal::DriverMode> {
     xfer: I2sParallelTransfer<'d, DmaTxBuf, DM>,
 }
 
 impl<'d, DM: esp_hal::DriverMode> Hub75Transfer<'d, DM> {
-    /// Returns `true` if the DMA transfer has completed.
+    /// Checks if the transfer is complete
+    ///
+    /// # Returns
+    /// `true` if the transfer is complete and `wait()` will not block
     #[cfg_attr(feature = "iram", ram)]
     pub fn is_done(&self) -> bool {
         self.xfer.is_done()
     }
 
-    /// Blocks until the DMA transfer completes and returns the driver for reuse.
+    /// Waits for the transfer to complete
+    ///
+    /// # Returns
+    /// A tuple containing:
+    /// 1. The result of the transfer
+    /// 2. The `Hub75` instance for reuse
+    ///
+    /// # Note
+    /// This method clears the transfer interrupt flag
     #[cfg_attr(feature = "iram", ram)]
     pub fn wait(self) -> (Result<(), DmaError>, Hub75<'d, DM>) {
         let (i2s, tx_buf) = self.xfer.wait();
@@ -152,7 +188,15 @@ impl<'d, DM: esp_hal::DriverMode> Hub75Transfer<'d, DM> {
 }
 
 impl Hub75Transfer<'_, esp_hal::Async> {
-    /// Asynchronously waits for the DMA transfer to complete.
+    /// Asynchronously waits for the transfer to complete
+    ///
+    /// # Returns
+    /// A `Result` indicating whether the transfer completed successfully
+    ///
+    /// # Note
+    /// This method does not return the `Hub75` instance. Use `wait()` after
+    /// `wait_for_done` returns to get the `Hub75` instance, it won't block at
+    /// that point.
     #[cfg_attr(feature = "iram", ram)]
     pub async fn wait_for_done(&mut self) -> Result<(), DmaError> {
         self.xfer.wait_for_done().await


### PR DESCRIPTION
Adds optional HUB75 CLK inversion (invert-clock) for the ESP32 I2S-parallel backend (clkphase-style) to support panels that require the opposite sampling edge (fixes column distortion / misaligned pixels).

Includes a checkerboard diagnostic example and README documentation.

Tested on a 96x48 panel using ICN2037BP.