### PR TITLE
add blank-delay features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### Added
+
+* `blank-delay-1` / `blank-delay-2` / `blank-delay-4` / `blank-delay-8` features
+  to control blanking cycles around row address changes (forwarded to
+  `hub75-framebuffer`).
+
 ## [0.11.0] - 2026-05-02
 
 ### ⚠️ Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ esp-hal = { version = "1.1.0", default-features = false, features = [
     "requires-unstable",
 ] }
 log = { version = "0.4.29", optional = true }
-hub75-framebuffer = { version = "0.8.0" }
+hub75-framebuffer = { version = "0.8.1" }
 esp-bootloader-esp-idf = "0.5.0"
 
 [dev-dependencies]
@@ -107,6 +107,11 @@ log = [
 ]
 invert-blank = [] # only for some latched implementations
 invert-clock = []
+
+blank-delay-1 = ["hub75-framebuffer/blank-delay-1"]
+blank-delay-2 = ["hub75-framebuffer/blank-delay-2"]
+blank-delay-4 = ["hub75-framebuffer/blank-delay-4"]
+blank-delay-8 = ["hub75-framebuffer/blank-delay-8"]
 
 # this feature is required for the docs.rs build and release builds to work
 esp-hal-unstable = ["esp-hal/unstable"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ examples (`parl_io_latch.rs`, `parl_io_bp_latch.rs`) can be used with it.
   Instruction RAM (IRAM) to avoid flash-cache stalls (for example during
   Wi-Fi, PSRAM, or SPI-flash activity) that can cause visible flicker.
   Enabling this feature consumes roughly 5–10 KiB of IRAM.
+- `blank-delay-1` / `blank-delay-2` / `blank-delay-4` / `blank-delay-8`:
+  Control the number of pixel-clock cycles of blanking (OE HIGH) inserted
+  around row address changes in the plain framebuffers (`plain` and
+  `bitplane::plain`). The blanking delay gives the address lines time to
+  settle before the new row is latched and lit, preventing ghosting or
+  "bleeding" artifacts between rows. These are forwarded directly to
+  `hub75-framebuffer`.
+
+  | Feature | Blanking cycles |
+  |---------|-----------------|
+  | *(none)* | 1 (default) |
+  | `blank-delay-1` | 1 |
+  | `blank-delay-2` | 2 |
+  | `blank-delay-4` | 4 |
+  | `blank-delay-8` | 8 |
+
+  Higher values reduce ghosting at the cost of slightly less brightness (the
+  LEDs are on for less time per scan line). Start with the default and increase
+  only if you observe row-transition artifacts on your particular panel
+  hardware.
 
 ##  Known Working Panels
 


### PR DESCRIPTION
Features to allow adjusting the blanking time around row address changes to reduce ghosting.

Related to: https://github.com/liebman/esp-hub75/issues/51