### PR TITLE
use  parallel interrupt api's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
+### ⚠️ Breaking
+
+* Removed the `I2sHub75Instance` trait. `Hub75::new` and `Hub75::new_async`
+  now use the `i2s::parallel::Instance` trait of esp-hal for the ESP32 (I2S
+  parallel) backend. Code with `I2S0` or `I2S1` needs no changes.
+
+* The ESP32 (I2S parallel) backend now uses the public interrupt API of
+  `I2sParallel` (`set_interrupt_handler`, `listen`,
+  `I2sParallelTransfer::clear_interrupts`). The old code used `steal()` and
+  wrote the `int_ena` and `int_clr` registers. The new code does not use
+  `steal()`. It removes 6 `unsafe` blocks. This needs the esp-hal change in
+  `../esp-hal` (upstream request #1 in `esp-hal.md`). All example crates now
+  use the local esp-hal tree.
+
 ## [0.16.0] - 2026-09-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Breaking
 
-* Removed the `I2sHub75Instance` trait. `Hub75::new` and `Hub75::new_async`
-  now use the `i2s::parallel::Instance` trait of esp-hal for the ESP32 (I2S
-  parallel) backend. Code with `I2S0` or `I2S1` needs no changes.
-
-* The ESP32 (I2S parallel) backend now uses the public interrupt API of
-  `I2sParallel` (`set_interrupt_handler`, `listen`,
-  `I2sParallelTransfer::clear_interrupts`). The old code used `steal()` and
-  wrote the `int_ena` and `int_clr` registers. The new code does not use
-  `steal()`. It removes 6 `unsafe` blocks. This needs the esp-hal change in
-  `../esp-hal` (upstream request #1 in `esp-hal.md`). All example crates now
-  use the local esp-hal tree.
+* Removed the `GdmaChannelNum` trait. The S3 backend now binds and enables its
+  interrupts through the new `esp-hal` `I8080` interrupt API
+  (`set_interrupt_handler` / `set_dma_interrupt_handler` / `listen` /
+  `listen_dma`), so the DMA channel number is no longer needed. This requires
+  an `esp-hal` build that includes the `I8080` interrupt API.
 
 ## [0.16.0] - 2026-09-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,16 +102,17 @@ cargo-args = ["-Z", "build-std=core"]
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../hub75-framebuffer" }
 # hub75-framebuffer = { git = "https://github.com/liebman/hub75-framebuffer.git", branch = "inter-row-blank" }
 
+[patch.crates-io]
 # esp-hal = { path = "../esp-hal/esp-hal" }
 # esp-riscv-rt = { path = "../esp-hal/esp-riscv-rt" }
 # xtensa-lx-rt = { path = "../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../esp-hal/esp-rom-sys" }
 
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ cargo-args = ["-Z", "build-std=core"]
 # xtensa-lx-rt = { path = "../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../esp-hal/esp-rom-sys" }
 
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,22 +102,16 @@ cargo-args = ["-Z", "build-std=core"]
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../hub75-framebuffer" }
 
-# [patch.crates-io]
+[patch.crates-io]
 # hub75-framebuffer = { path = "../hub75-framebuffer" }
 # hub75-framebuffer = { git = "https://github.com/liebman/hub75-framebuffer.git", branch = "inter-row-blank" }
 
-# esp-backtrace    = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-# esp-hal          = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-# esp-rtos  = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-# esp-println      = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-# esp-riscv-rt     = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-# xtensa-lx-rt     = { git = "https://github.com/esp-rs/esp-hal.git", branch = "main" }
-
-# esp-backtrace = { path = "../esp-hal/esp-backtrace" }
-# # esp-build = { path = "../esp-hal/esp-build" }
 # esp-hal = { path = "../esp-hal/esp-hal" }
-# esp-rtos = { path = "../esp-hal/esp-rtos" }
-# esp-println = { path = "../esp-hal/esp-println" }
 # esp-riscv-rt = { path = "../esp-hal/esp-riscv-rt" }
 # xtensa-lx-rt = { path = "../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../esp-hal/esp-rom-sys" }
+
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ cargo-args = ["-Z", "build-std=core"]
 # xtensa-lx-rt = { path = "../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../esp-hal/esp-rom-sys" }
 
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/examples/gradient-embassy/Cargo.toml
+++ b/examples/gradient-embassy/Cargo.toml
@@ -119,25 +119,35 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch."https://github.com/liebman/hub75-framebuffer.git"]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
 # esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
 # esp-hal = { path = "../../../esp-hal/esp-hal" }
-# esp-rtos = { path = "../../../esp-hal/esp-rtos" }
 # esp-println = { path = "../../../esp-hal/esp-println" }
 # esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rtos = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+[patch.crates-io]
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+# # needed so the registry `esp-rtos` dep unifies with the fork's `esp-sync`
+# # (which receives the chip features forwarded by `esp-hal`)
+# esp-sync = { path = "../../../esp-hal/esp-sync" }
+
+esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-sync = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/examples/gradient-embassy/Cargo.toml
+++ b/examples/gradient-embassy/Cargo.toml
@@ -133,11 +133,11 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rtos = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rtos = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/examples/gradient-embassy/Cargo.toml
+++ b/examples/gradient-embassy/Cargo.toml
@@ -22,7 +22,7 @@ embassy-executor = { version = "0.10.0" }
 embassy-time = { version = "0.5.1" }
 embedded-graphics = { version = "0.8.2" }
 esp-backtrace = { version = "0.20.0", features = ["panic-handler"] }
-esp-bootloader-esp-idf = "0.5.0"
+esp-bootloader-esp-idf = "0.6.0"
 esp-hal = { version = "1.2.0", features = ["unstable"] }
 esp-println = { version = "0.18.0" }
 esp-rtos = { version = "0.4.0", features = ["embassy"] }
@@ -119,8 +119,25 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch.crates-io]
-# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
-
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+[patch.crates-io]
+# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-rtos = { path = "../../../esp-hal/esp-rtos" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rtos = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/examples/gradient-embassy/Cargo.toml
+++ b/examples/gradient-embassy/Cargo.toml
@@ -143,11 +143,11 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # # (which receives the chip features forwarded by `esp-hal`)
 # esp-sync = { path = "../../../esp-hal/esp-sync" }
 
-esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-sync = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-sync = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/examples/gradient-latched/Cargo.toml
+++ b/examples/gradient-latched/Cargo.toml
@@ -112,10 +112,10 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch."https://github.com/liebman/hub75-framebuffer.git"]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
 # esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
@@ -125,10 +125,18 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+[patch.crates-io]
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/examples/gradient-latched/Cargo.toml
+++ b/examples/gradient-latched/Cargo.toml
@@ -125,10 +125,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/examples/gradient-latched/Cargo.toml
+++ b/examples/gradient-latched/Cargo.toml
@@ -133,10 +133,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/examples/gradient-latched/Cargo.toml
+++ b/examples/gradient-latched/Cargo.toml
@@ -20,7 +20,7 @@ esp-hub75 = { path = "../..", default-features = false }
 
 embedded-graphics = { version = "0.8.2" }
 esp-backtrace = { version = "0.20.0", features = ["panic-handler"] }
-esp-bootloader-esp-idf = "0.5.0"
+esp-bootloader-esp-idf = "0.6.0"
 esp-hal = { version = "1.2.0", features = ["unstable"] }
 esp-println = { version = "0.18.0" }
 heapless = { version = "0.9.3", features = ["ufmt"] }
@@ -112,8 +112,23 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch.crates-io]
-# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
-
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+[patch.crates-io]
+# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/examples/gradient-quarter/Cargo.toml
+++ b/examples/gradient-quarter/Cargo.toml
@@ -113,10 +113,10 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch."https://github.com/liebman/hub75-framebuffer.git"]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
 # esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
@@ -126,10 +126,18 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+[patch.crates-io]
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/examples/gradient-quarter/Cargo.toml
+++ b/examples/gradient-quarter/Cargo.toml
@@ -126,10 +126,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/examples/gradient-quarter/Cargo.toml
+++ b/examples/gradient-quarter/Cargo.toml
@@ -20,7 +20,7 @@ esp-hub75 = { path = "../..", default-features = false }
 
 embedded-graphics = { version = "0.8.2" }
 esp-backtrace = { version = "0.20.0", features = ["panic-handler"] }
-esp-bootloader-esp-idf = "0.5.0"
+esp-bootloader-esp-idf = "0.6.0"
 esp-hal = { version = "1.2.0", features = ["unstable"] }
 esp-println = { version = "0.18.0" }
 heapless = { version = "0.9.3", features = ["ufmt"] }
@@ -113,8 +113,23 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch.crates-io]
-# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
-
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+[patch.crates-io]
+# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/examples/gradient-quarter/Cargo.toml
+++ b/examples/gradient-quarter/Cargo.toml
@@ -134,10 +134,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/examples/gradient-tiled/Cargo.toml
+++ b/examples/gradient-tiled/Cargo.toml
@@ -112,10 +112,10 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch."https://github.com/liebman/hub75-framebuffer.git"]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
 # esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
@@ -125,10 +125,18 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+[patch.crates-io]
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/examples/gradient-tiled/Cargo.toml
+++ b/examples/gradient-tiled/Cargo.toml
@@ -125,10 +125,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/examples/gradient-tiled/Cargo.toml
+++ b/examples/gradient-tiled/Cargo.toml
@@ -133,10 +133,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/examples/gradient-tiled/Cargo.toml
+++ b/examples/gradient-tiled/Cargo.toml
@@ -20,7 +20,7 @@ esp-hub75 = { path = "../..", default-features = false }
 
 embedded-graphics = { version = "0.8.2" }
 esp-backtrace = { version = "0.20.0", features = ["panic-handler"] }
-esp-bootloader-esp-idf = "0.5.0"
+esp-bootloader-esp-idf = "0.6.0"
 esp-hal = { version = "1.2.0", features = ["unstable"] }
 esp-println = { version = "0.18.0" }
 heapless = { version = "0.9.3", features = ["ufmt"] }
@@ -112,8 +112,23 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch.crates-io]
-# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
-
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+[patch.crates-io]
+# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/examples/gradient/Cargo.toml
+++ b/examples/gradient/Cargo.toml
@@ -113,10 +113,10 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch."https://github.com/liebman/hub75-framebuffer.git"]
+# [patch.crates-io]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
-[patch.crates-io]
+# [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
 
 # esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
@@ -126,10 +126,18 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+[patch.crates-io]
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }

--- a/examples/gradient/Cargo.toml
+++ b/examples/gradient/Cargo.toml
@@ -126,10 +126,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
-esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "526d4bb68f144b0e4384afcbb1d36bf0f94f7cdc" }

--- a/examples/gradient/Cargo.toml
+++ b/examples/gradient/Cargo.toml
@@ -20,7 +20,7 @@ esp-hub75 = { path = "../..", default-features = false }
 
 embedded-graphics = { version = "0.8.2" }
 esp-backtrace = { version = "0.20.0", features = ["panic-handler"] }
-esp-bootloader-esp-idf = "0.5.0"
+esp-bootloader-esp-idf = "0.6.0"
 esp-hal = { version = "1.2.0", features = ["unstable"] }
 esp-println = { version = "0.18.0" }
 heapless = { version = "0.9.3", features = ["ufmt"] }
@@ -113,8 +113,23 @@ inter-row-blank-32 = ["esp-hub75/inter-row-blank-32"]
 reverse-row-order = ["esp-hub75/reverse-row-order"]
 esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 
-# [patch.crates-io]
-# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
-
 # [patch."https://github.com/liebman/hub75-framebuffer.git"]
 # hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+[patch.crates-io]
+# hub75-framebuffer = { path = "../../../hub75-framebuffer" }
+
+# esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
+# esp-hal = { path = "../../../esp-hal/esp-hal" }
+# esp-println = { path = "../../../esp-hal/esp-println" }
+# esp-riscv-rt = { path = "../../../esp-hal/esp-riscv-rt" }
+# xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
+# esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
+
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "c9240a08b35cb6bfab7eff8cf336cb2797d07946" }

--- a/examples/gradient/Cargo.toml
+++ b/examples/gradient/Cargo.toml
@@ -134,10 +134,10 @@ esp-hal-unstable = ["esp-hub75/esp-hal-unstable"]
 # xtensa-lx-rt = { path = "../../../esp-hal/xtensa-lx-rt" }
 # esp-rom-sys = { path = "../../../esp-hal/esp-rom-sys" }
 
-esp-backtrace = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-hal = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-println = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-riscv-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-xtensa-lx-rt = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-rom-sys = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
-esp-storage = { git = "https://github.com/liebman/esp-hal.git", branch = "i8080-interrupts" }
+esp-backtrace = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-hal = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-println = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-riscv-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+xtensa-lx-rt = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-rom-sys = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }
+esp-storage = { git = "https://github.com/esp-rs/esp-hal.git", rev = "88887f13b94f4d02fc12d19ae14e78fdd2ab1f45" }

--- a/src/i2s_parallel.rs
+++ b/src/i2s_parallel.rs
@@ -1,8 +1,10 @@
 //! HUB75 driver for I2S Parallel peripherals (ESP32).
 //!
-//! The I2S DMA `out_total_eof` interrupt runs the BCM (Binary Code
-//! Modulation) refresh loop, so the panel keeps scanning out the current
-//! framebuffer on its own. Buffer swaps take effect at frame boundaries.
+//! The I2S DMA `out_total_eof` interrupt runs the BCM loop . In
+//! circular-DMA mode, the per-descriptor `out_eof` interrupt runs the
+//! loop. The loop sends the framebuffer data to the panel again and
+//! again. The panel shows the current framebuffer by itself. A buffer
+//! swap starts at a frame boundary.
 //!
 //! # Blocking example
 //!
@@ -34,10 +36,11 @@ use esp_hal::gpio::AnyPin;
 use esp_hal::gpio::NoPin;
 use esp_hal::i2s::parallel::I2sParallel;
 use esp_hal::i2s::parallel::I2sParallelDmaChannel;
+use esp_hal::i2s::parallel::I2sParallelInterrupt;
+use esp_hal::i2s::parallel::Instance;
 use esp_hal::i2s::parallel::TxEightBits;
 use esp_hal::i2s::parallel::TxPins;
 use esp_hal::i2s::parallel::TxSixteenBits;
-use esp_hal::peripherals::Interrupt;
 use esp_hal::time::Rate;
 
 use crate::Hub75Error;
@@ -51,118 +54,6 @@ use crate::bcm::linear::BcmBuf;
 pub use crate::isr::Hub75;
 
 // ---------------------------------------------------------------------------
-// I2S instance trait: maps concrete peripherals to their interrupt and
-// register block for enabling `out_total_eof`.
-// ---------------------------------------------------------------------------
-
-/// Interrupt binding and `out_total_eof` setup for I2S0 and I2S1.
-///
-/// You never implement or call this directly; just pass `peripherals.I2S0`
-/// or `peripherals.I2S1` to the constructor.
-pub trait I2sHub75Instance: esp_hal::i2s::parallel::Instance {
-    #[doc(hidden)]
-    fn bind_and_enable_isr();
-
-    #[doc(hidden)]
-    fn clear_interrupt();
-}
-
-impl I2sHub75Instance for esp_hal::peripherals::I2S0<'_> {
-    fn bind_and_enable_isr() {
-        // SAFETY: `I2sParallel::new` has consumed the I2S0 peripheral. We
-        // steal a second handle only to flip the interrupt-enable bit, which
-        // esp-hal's I2S driver doesn't expose. The ISR isn't active yet, so
-        // no data race.
-        #[cfg(not(feature = "circular-dma"))]
-        unsafe {
-            esp_hal::interrupt::bind_handler(Interrupt::I2S0, crate::isr::hub75_isr);
-            let stolen = esp_hal::peripherals::I2S0::steal();
-            let reg = stolen.register_block();
-            reg.int_ena().modify(|_, w| w.out_total_eof().set_bit());
-        }
-        #[cfg(feature = "circular-dma")]
-        unsafe {
-            esp_hal::interrupt::bind_handler(Interrupt::I2S0, crate::isr::hub75_frame_count_isr);
-            let stolen = esp_hal::peripherals::I2S0::steal();
-            let reg = stolen.register_block();
-            // Use `out_eof` (per-descriptor EOF) rather than
-            // `out_total_eof` because, in a circular DMA chain, the
-            // transfer never ends, so `out_total_eof` never fires. The
-            // per-descriptor `out_eof` fires whenever a descriptor with
-            // `suc_eof=1` is encountered, even when `next` points back
-            // to the ring start. This has been hardware-tested and
-            // confirmed working on ESP32 classic (I2S LCD mode).
-            //
-            // TODO: esp-hal's I2S parallel driver only uses
-            // `out_total_eof` internally; exposing a way to use
-            // per-descriptor `out_eof` for circular chains (or at least
-            // documenting the register-level workaround) would let us
-            // drop this PAC-level register manipulation.
-            reg.int_ena().modify(|_, w| w.out_eof().set_bit());
-        }
-    }
-
-    fn clear_interrupt() {
-        unsafe {
-            let stolen = esp_hal::peripherals::I2S0::steal();
-            let reg = stolen.register_block();
-            #[cfg(not(feature = "circular-dma"))]
-            reg.int_clr()
-                .write(|w| w.out_total_eof().clear_bit_by_one());
-            #[cfg(feature = "circular-dma")]
-            reg.int_clr().write(|w| w.out_eof().clear_bit_by_one());
-        }
-    }
-}
-
-impl I2sHub75Instance for esp_hal::peripherals::I2S1<'_> {
-    fn bind_and_enable_isr() {
-        // SAFETY: Same justification as I2S0 above: we only touch the
-        // interrupt-enable bit, which the esp-hal driver doesn't contest,
-        // and this runs during init.
-        #[cfg(not(feature = "circular-dma"))]
-        unsafe {
-            esp_hal::interrupt::bind_handler(Interrupt::I2S1, crate::isr::hub75_isr);
-            let stolen = esp_hal::peripherals::I2S1::steal();
-            let reg = stolen.register_block();
-            reg.int_ena().modify(|_, w| w.out_total_eof().set_bit());
-        }
-        #[cfg(feature = "circular-dma")]
-        unsafe {
-            esp_hal::interrupt::bind_handler(Interrupt::I2S1, crate::isr::hub75_frame_count_isr);
-            let stolen = esp_hal::peripherals::I2S1::steal();
-            let reg = stolen.register_block();
-            // Use `out_eof` (per-descriptor EOF) rather than
-            // `out_total_eof` because, in a circular DMA chain, the
-            // transfer never ends, so `out_total_eof` never fires. The
-            // per-descriptor `out_eof` fires whenever a descriptor with
-            // `suc_eof=1` is encountered, even when `next` points back
-            // to the ring start. This has been hardware-tested and
-            // confirmed working on ESP32 classic (I2S LCD mode).
-            //
-            // TODO: esp-hal's I2S parallel driver only uses
-            // `out_total_eof` internally; exposing a way to use
-            // per-descriptor `out_eof` for circular chains (or at least
-            // documenting the register-level workaround) would let us
-            // drop this PAC-level register manipulation.
-            reg.int_ena().modify(|_, w| w.out_eof().set_bit());
-        }
-    }
-
-    fn clear_interrupt() {
-        unsafe {
-            let stolen = esp_hal::peripherals::I2S1::steal();
-            let reg = stolen.register_block();
-            #[cfg(not(feature = "circular-dma"))]
-            reg.int_clr()
-                .write(|w| w.out_total_eof().clear_bit_by_one());
-            #[cfg(feature = "circular-dma")]
-            reg.int_clr().write(|w| w.out_eof().clear_bit_by_one());
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Constructor
 // ---------------------------------------------------------------------------
 
@@ -171,7 +62,7 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
     fn new_internal<
         T: TxPins<'static> + 'static,
         P: Hub75Pins<'static, T, Word = FB::Word>,
-        I: I2sHub75Instance + 'static,
+        I: Instance + 'static,
     >(
         i2s: I,
         hub75_pins: P,
@@ -191,11 +82,13 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         #[cfg(not(feature = "invert-clock"))]
         let clock_pin = clock_pin.into_output_signal().with_output_inverter(true);
 
-        let i2s_parallel = I2sParallel::new(i2s, channel, frequency, pins, clock_pin);
+        let mut i2s_parallel = I2sParallel::new(i2s, channel, frequency, pins, clock_pin);
 
-        // Bind our ISR and enable the interrupt so we get notified on each
-        // DMA transfer completion.
-        I::bind_and_enable_isr();
+        // This connects `hub75_isr` to the interrupt and turns on the
+        // `out_total_eof` source. The `out_total_eof` interrupt occurs when
+        // the DMA finishes the full DMA descriptor chain.
+        i2s_parallel.set_interrupt_handler(crate::isr::hub75_isr);
+        i2s_parallel.listen(I2sParallelInterrupt::TotalEof);
 
         let buf = BcmBuf::new(tx_descriptors);
         crate::isr::init_isr_state(i2s_parallel, buf);
@@ -210,7 +103,7 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
     fn new_internal<
         T: TxPins<'static> + 'static,
         P: Hub75Pins<'static, T, Word = FB::Word>,
-        I: I2sHub75Instance + 'static,
+        I: Instance + 'static,
     >(
         i2s: I,
         hub75_pins: P,
@@ -231,11 +124,17 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         #[cfg(not(feature = "invert-clock"))]
         let clock_pin = clock_pin.into_output_signal().with_output_inverter(true);
 
-        let i2s_parallel = I2sParallel::new(i2s, channel, frequency, pins, clock_pin);
+        let mut i2s_parallel = I2sParallel::new(i2s, channel, frequency, pins, clock_pin);
 
-        // Bind the frame-count ISR if enabled; otherwise the DMA runs
-        // silently with no interrupts.
-        I::bind_and_enable_isr();
+        // This connects `hub75_frame_count_isr` to the interrupt and turns
+        // on the per-descriptor `out_eof` source. The `out_eof` interrupt
+        // occurs each time the DMA finds a descriptor with `suc_eof=1`.
+        // This is also true for a circular chain , where `next` points
+        // back to the start of the chain. We checked this on the hardware
+        // (ESP32 classic, I2S LCD mode). `out_total_eof` never occurs on a
+        // circular chain, because the transfer never ends.
+        i2s_parallel.set_interrupt_handler(crate::isr::hub75_frame_count_isr);
+        i2s_parallel.listen(I2sParallelInterrupt::Eof);
 
         let mut buf = CircularBcmBuf::new(tx_descriptors, fb);
         let desc_ptr = buf.descriptors_ptr();
@@ -247,8 +146,6 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
             .map_err(|(err, _tx, _buf)| Hub75Error::Dma(err))?;
 
         crate::isr::store_circular_state(xfer, desc_ptr, desc_count, fb_ptr);
-
-        crate::isr::store_clear_interrupt(I::clear_interrupt);
 
         Ok(Self::from_phantom())
     }
@@ -283,7 +180,7 @@ impl<FB: crate::framebuffer::FrameBuffer + 'static> Hub75<Blocking, FB> {
     pub fn new<
         T: TxPins<'static> + 'static,
         P: Hub75Pins<'static, T, Word = FB::Word>,
-        I: I2sHub75Instance + 'static,
+        I: Instance + 'static,
     >(
         i2s: I,
         hub75_pins: P,
@@ -325,7 +222,7 @@ impl<FB: crate::framebuffer::FrameBuffer + 'static> Hub75<esp_hal::Async, FB> {
     pub fn new_async<
         T: TxPins<'static> + 'static,
         P: Hub75Pins<'static, T, Word = FB::Word>,
-        I: I2sHub75Instance + 'static,
+        I: Instance + 'static,
     >(
         i2s: I,
         hub75_pins: P,

--- a/src/isr.rs
+++ b/src/isr.rs
@@ -109,8 +109,13 @@ static ISR_STATE: SharedIsrState = Mutex::new(RefCell::new(None));
 
 #[cfg(feature = "circular-dma")]
 pub(crate) struct CircularState {
-    // kept alive to prevent DMA from stopping
-    pub(crate) _transfer: Option<TxTransfer>,
+    // The driver keeps this transfer in the state. Without it, the DMA
+    // stops. The I2S backend  also uses the transfer to clear the
+    // `out_eof` flag (see `clear_frame_interrupt`). The LCD_CAM backend
+    // does not read the field. It only keeps the transfer alive. This
+    // allow stops the dead-code warning on the S3.
+    #[cfg_attr(hub75_use_lcd_cam, allow(dead_code))]
+    pub(crate) transfer: Option<TxTransfer>,
     pub(crate) descriptors: *mut esp_hal::dma::DmaDescriptor,
     pub(crate) desc_count: usize,
     pub(crate) current_fb_ptr: *const (),
@@ -144,7 +149,16 @@ static DRIVER_TAKEN: AtomicBool = AtomicBool::new(false);
 static SWAP_WAKER: Mutex<RefCell<Option<Waker>>> = Mutex::new(RefCell::new(None));
 static FRAME_COUNT: AtomicU32 = AtomicU32::new(0);
 
-#[cfg(feature = "circular-dma")]
+/// The frame-count ISR uses this function  to clear the interrupt
+/// flag. Only the ESP32-S3 (`LCD_CAM`) backend  stores a function here.
+///
+/// The frame interrupt of the S3 comes from the GDMA channel, not from the
+/// `LCD_CAM` peripheral. esp-hal does not give the code control of that
+/// interrupt yet (see `esp-hal.md` §3). The stored function uses
+/// `DMA::steal()` to clear the flag. The ESP32 (I2S) backend stores no
+/// function. It clears the flag through the stored transfer (see
+/// `clear_frame_interrupt`).
+#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
 #[allow(clippy::type_complexity)]
 static CLEAR_INTERRUPT: Mutex<RefCell<Option<fn()>>> = Mutex::new(RefCell::new(None));
 
@@ -290,18 +304,48 @@ pub(crate) fn hub75_isr() {
 #[cfg_attr(feature = "iram", ram)]
 pub(crate) fn hub75_frame_count_isr() {
     critical_section::with(|cs| {
+        // The DMA is now at a frame boundary. It starts the chain again
+        // . It sends only data from the new buffer now. Clear the flag.
+        // The next `swap()` can then start.
+        if let Some(state) = CIRCULAR_STATE.borrow_ref_mut(cs).as_mut() {
+            clear_frame_interrupt(cs, state);
+            state.swap_in_flight = false;
+        }
+        FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
+        signal_swap_done(cs);
+    });
+}
+
+/// This function clears the frame interrupt flag. It does this for the
+/// circular-DMA backend  that the chip uses.
+///
+/// Borrow `state` from `CIRCULAR_STATE` before this function runs. Hold
+/// the critical section while this function runs.
+#[cfg(feature = "circular-dma")]
+fn clear_frame_interrupt(cs: critical_section::CriticalSection, state: &mut CircularState) {
+    // ESP32 (I2S): the transfer clears its own `out_eof` flag. esp-hal
+    // supplies `I2sParallelTransfer::clear_interrupts` for this. You do not
+    // need `steal()` here (esp-hal.md §1).
+    #[cfg(hub75_use_i2s_parallel)]
+    {
+        let _ = cs; // The I2S branch does not use `cs`.
+        if let Some(xfer) = state.transfer.as_mut() {
+            use esp_hal::i2s::parallel::I2sParallelInterrupt;
+            xfer.clear_interrupts(I2sParallelInterrupt::Eof);
+        }
+    }
+
+    // ESP32-S3 (LCD_CAM): the frame interrupt comes from the GDMA channel.
+    // esp-hal does not give the code control of this interrupt yet
+    // (esp-hal.md §3). The stored function  uses `DMA::steal()` to
+    // clear the flag.
+    #[cfg(hub75_use_lcd_cam)]
+    {
+        let _ = state;
         if let Some(clear) = CLEAR_INTERRUPT.borrow_ref(cs).as_ref() {
             (clear)();
         }
-        FRAME_COUNT.fetch_add(1, Ordering::Relaxed);
-        // A frame boundary has passed — the DMA has completed one full pass
-        // and is reading exclusively from the new buffer. Clear the flag so
-        // the next `swap()` is permitted.
-        if let Some(state) = CIRCULAR_STATE.borrow_ref_mut(cs).as_mut() {
-            state.swap_in_flight = false;
-        }
-        signal_swap_done(cs);
-    });
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -347,7 +391,7 @@ pub(crate) fn store_circular_state(
 ) {
     critical_section::with(|cs| {
         *CIRCULAR_STATE.borrow_ref_mut(cs) = Some(CircularState {
-            _transfer: Some(xfer),
+            transfer: Some(xfer),
             descriptors: desc_ptr,
             desc_count,
             current_fb_ptr: fb_ptr,
@@ -356,7 +400,7 @@ pub(crate) fn store_circular_state(
     });
 }
 
-#[cfg(feature = "circular-dma")]
+#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
 pub(crate) fn store_clear_interrupt(clear: fn()) {
     critical_section::with(|cs| {
         *CLEAR_INTERRUPT.borrow_ref_mut(cs) = Some(clear);
@@ -814,9 +858,7 @@ impl<DM: esp_hal::DriverMode, FB: FrameBuffer + 'static> Hub75<DM, FB> {
             // An ISR triggered on a pre-update EOF would incorrectly attribute
             // the boundary to the new buffer and prematurely release the old
             // framebuffer while DMA may still be reading from it.
-            if let Some(clear) = CLEAR_INTERRUPT.borrow_ref(cs).as_ref() {
-                (clear)();
-            }
+            clear_frame_interrupt(cs, state);
             let old_ptr = state.current_fb_ptr;
             state.current_fb_ptr = new_fb_ptr as *const ();
             SWAP_DONE.store(false, Ordering::Release);

--- a/src/isr.rs
+++ b/src/isr.rs
@@ -13,6 +13,8 @@ use core::task::Waker;
 
 use critical_section::Mutex;
 use esp_hal::Blocking;
+#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
+use esp_hal::dma::DmaTxInterrupt;
 use esp_hal::handler;
 #[cfg(feature = "iram")]
 use esp_hal::ram;
@@ -64,6 +66,45 @@ pub(crate) type TxTransfer =
     esp_hal::lcd_cam::lcd::i8080::I8080Transfer<'static, CircularBcmBuf, Blocking>;
 
 // ---------------------------------------------------------------------------
+// Frame-boundary interrupt handling (circular-dma only)
+// ---------------------------------------------------------------------------
+
+/// Clears the frame-boundary DMA interrupt (`out_eof`) through the transfer
+/// kept alive in [`CircularState`], so no `DMA::steal()` or stored closure is
+/// needed on any backend.
+#[cfg(feature = "circular-dma")]
+pub(crate) trait FrameInterrupt {
+    /// Clear a pending `out_eof` flag. Called from the frame-count ISR and
+    /// from `swap()` to drain EOFs latched before the buffer pointer update.
+    fn clear_frame_interrupt(&self);
+
+    /// Enable the `out_eof` source. Called once from `store_circular_state`,
+    /// after the transfer is stored and a latched EOF was drained. Only
+    /// backends that start the DMA engine before the transfer is stored need
+    /// to enable the source here; the rest listen in the constructor.
+    fn listen_frame_interrupt(&self) {}
+}
+
+#[cfg(all(feature = "circular-dma", hub75_use_i2s_parallel))]
+impl FrameInterrupt for TxTransfer {
+    fn clear_frame_interrupt(&self) {
+        use esp_hal::i2s::parallel::I2sParallelInterrupt;
+        self.clear_interrupts(I2sParallelInterrupt::Eof);
+    }
+}
+
+#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
+impl FrameInterrupt for TxTransfer {
+    fn clear_frame_interrupt(&self) {
+        self.clear_interrupts_dma(DmaTxInterrupt::Eof);
+    }
+
+    fn listen_frame_interrupt(&self) {
+        self.listen_dma(DmaTxInterrupt::Eof);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // ISR shared state
 // ---------------------------------------------------------------------------
 
@@ -109,12 +150,9 @@ static ISR_STATE: SharedIsrState = Mutex::new(RefCell::new(None));
 
 #[cfg(feature = "circular-dma")]
 pub(crate) struct CircularState {
-    // The driver keeps this transfer in the state. Without it, the DMA
-    // stops. The I2S backend  also uses the transfer to clear the
-    // `out_eof` flag (see `clear_frame_interrupt`). The LCD_CAM backend
-    // does not read the field. It only keeps the transfer alive. This
-    // allow stops the dead-code warning on the S3.
-    #[cfg_attr(hub75_use_lcd_cam, allow(dead_code))]
+    // Kept alive to prevent the DMA from stopping. Both backends also use
+    // the stored transfer to clear the frame-boundary `out_eof` flag (see
+    // `FrameInterrupt` and `clear_frame_interrupt`).
     pub(crate) transfer: Option<TxTransfer>,
     pub(crate) descriptors: *mut esp_hal::dma::DmaDescriptor,
     pub(crate) desc_count: usize,
@@ -148,19 +186,6 @@ static HAS_ERROR: AtomicBool = AtomicBool::new(false);
 static DRIVER_TAKEN: AtomicBool = AtomicBool::new(false);
 static SWAP_WAKER: Mutex<RefCell<Option<Waker>>> = Mutex::new(RefCell::new(None));
 static FRAME_COUNT: AtomicU32 = AtomicU32::new(0);
-
-/// The frame-count ISR uses this function  to clear the interrupt
-/// flag. Only the ESP32-S3 (`LCD_CAM`) backend  stores a function here.
-///
-/// The frame interrupt of the S3 comes from the GDMA channel, not from the
-/// `LCD_CAM` peripheral. esp-hal does not give the code control of that
-/// interrupt yet (see `esp-hal.md` §3). The stored function uses
-/// `DMA::steal()` to clear the flag. The ESP32 (I2S) backend stores no
-/// function. It clears the flag through the stored transfer (see
-/// `clear_frame_interrupt`).
-#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
-#[allow(clippy::type_complexity)]
-static CLEAR_INTERRUPT: Mutex<RefCell<Option<fn()>>> = Mutex::new(RefCell::new(None));
 
 fn signal_swap_done(cs: critical_section::CriticalSection) {
     SWAP_DONE.store(true, Ordering::Release);
@@ -305,7 +330,7 @@ pub(crate) fn hub75_isr() {
 pub(crate) fn hub75_frame_count_isr() {
     critical_section::with(|cs| {
         // The DMA is now at a frame boundary. It starts the chain again
-        // . It sends only data from the new buffer now. Clear the flag.
+        // and sends only data from the new buffer now. Clear the flag.
         // The next `swap()` can then start.
         if let Some(state) = CIRCULAR_STATE.borrow_ref_mut(cs).as_mut() {
             clear_frame_interrupt(cs, state);
@@ -317,34 +342,18 @@ pub(crate) fn hub75_frame_count_isr() {
 }
 
 /// This function clears the frame interrupt flag. It does this for the
-/// circular-DMA backend  that the chip uses.
+/// circular-DMA backend that the chip uses.
 ///
 /// Borrow `state` from `CIRCULAR_STATE` before this function runs. Hold
 /// the critical section while this function runs.
 #[cfg(feature = "circular-dma")]
 fn clear_frame_interrupt(cs: critical_section::CriticalSection, state: &mut CircularState) {
-    // ESP32 (I2S): the transfer clears its own `out_eof` flag. esp-hal
-    // supplies `I2sParallelTransfer::clear_interrupts` for this. You do not
-    // need `steal()` here (esp-hal.md §1).
-    #[cfg(hub75_use_i2s_parallel)]
-    {
-        let _ = cs; // The I2S branch does not use `cs`.
-        if let Some(xfer) = state.transfer.as_mut() {
-            use esp_hal::i2s::parallel::I2sParallelInterrupt;
-            xfer.clear_interrupts(I2sParallelInterrupt::Eof);
-        }
-    }
-
-    // ESP32-S3 (LCD_CAM): the frame interrupt comes from the GDMA channel.
-    // esp-hal does not give the code control of this interrupt yet
-    // (esp-hal.md §3). The stored function  uses `DMA::steal()` to
-    // clear the flag.
-    #[cfg(hub75_use_lcd_cam)]
-    {
-        let _ = state;
-        if let Some(clear) = CLEAR_INTERRUPT.borrow_ref(cs).as_ref() {
-            (clear)();
-        }
+    // The clear goes through the transfer stored in the driver state. Each
+    // target implements `FrameInterrupt` for its `TxTransfer` type, so no
+    // `DMA::steal()` is needed on any backend.
+    let _ = cs;
+    if let Some(xfer) = state.transfer.as_ref() {
+        xfer.clear_frame_interrupt();
     }
 }
 
@@ -397,13 +406,21 @@ pub(crate) fn store_circular_state(
             current_fb_ptr: fb_ptr,
             swap_in_flight: false,
         });
-    });
-}
 
-#[cfg(all(feature = "circular-dma", hub75_use_lcd_cam))]
-pub(crate) fn store_clear_interrupt(clear: fn()) {
-    critical_section::with(|cs| {
-        *CLEAR_INTERRUPT.borrow_ref_mut(cs) = Some(clear);
+        // ESP32-S3 (LCD_CAM) only: the DMA chain started in `send()` before
+        // the transfer was stored here, so an `out_eof` may have latched
+        // while the source was disabled (the enable bit only gates the CPU
+        // interrupt; the raw status bit still latches). Drain it now, then
+        // enable the source. From this point on, every interrupt can be
+        // serviced through the transfer stored in this state, and none can
+        // fire before that was the case.
+        {
+            let mut state_ref = CIRCULAR_STATE.borrow_ref_mut(cs);
+            let state = state_ref.as_mut().expect("just stored");
+            let transfer = state.transfer.as_ref().expect("transfer kept alive");
+            transfer.clear_frame_interrupt();
+            transfer.listen_frame_interrupt();
+        }
     });
 }
 

--- a/src/lcd_cam.rs
+++ b/src/lcd_cam.rs
@@ -97,7 +97,7 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         // flag before starting the LCD, so the ISR cannot fire before the
         // ISR state is initialised below.
         i8080.set_interrupt_handler(crate::isr::hub75_isr);
-        i8080.listen(I8080Interrupt::LcdTransDone);
+        i8080.listen(I8080Interrupt::TransDone);
 
         let buf = BcmBuf::new(tx_descriptors);
         crate::isr::init_isr_state(i8080, buf, word_size);

--- a/src/lcd_cam.rs
+++ b/src/lcd_cam.rs
@@ -43,6 +43,8 @@ use esp_hal::lcd_cam::lcd::i8080;
 #[cfg(feature = "circular-dma")]
 use esp_hal::lcd_cam::lcd::i8080::Command;
 use esp_hal::lcd_cam::lcd::i8080::I8080;
+#[cfg(not(feature = "circular-dma"))]
+use esp_hal::lcd_cam::lcd::i8080::I8080Interrupt;
 use esp_hal::peripherals::LCD_CAM;
 use esp_hal::time::Rate;
 
@@ -75,8 +77,7 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
 
         let word_size = hub75_pins.word_size();
 
-        let mut lcd_cam_dev = LcdCam::new(lcd_cam);
-        lcd_cam_dev.set_interrupt_handler(crate::isr::hub75_isr);
+        let lcd_cam_dev = LcdCam::new(lcd_cam);
 
         let config = {
             let c = i8080::Config::default().with_frequency(frequency);
@@ -89,19 +90,14 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         };
 
         let i8080 = I8080::new(lcd_cam_dev.lcd, channel, config).map_err(Hub75Error::I8080)?;
-        let i8080 = hub75_pins.apply(i8080);
+        let mut i8080 = hub75_pins.apply(i8080);
 
-        // SAFETY: The `I8080` driver above owns the LCD_CAM peripheral. We
-        // steal a second handle only to set the `lcd_trans_done`
-        // interrupt-enable bit, which esp-hal doesn't expose. The ISR isn't
-        // active yet, so no data race.
-        unsafe {
-            let stolen = LCD_CAM::steal();
-            stolen
-                .register_block()
-                .lc_dma_int_ena()
-                .modify(|_, w| w.lcd_trans_done_int_ena().set_bit());
-        }
+        // Bind the BCM refresh ISR to the LCD_CAM interrupt and enable the
+        // `lcd_trans_done` source. `send()` clears a pending `lcd_trans_done`
+        // flag before starting the LCD, so the ISR cannot fire before the
+        // ISR state is initialised below.
+        i8080.set_interrupt_handler(crate::isr::hub75_isr);
+        i8080.listen(I8080Interrupt::LcdTransDone);
 
         let buf = BcmBuf::new(tx_descriptors);
         crate::isr::init_isr_state(i8080, buf, word_size);
@@ -116,7 +112,7 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
     fn new_internal<P: Hub75Pins<'static, Word = FB::Word>>(
         lcd_cam: LCD_CAM<'static>,
         hub75_pins: P,
-        channel: impl LcdDmaTxChannel<'static> + crate::GdmaChannelNum,
+        channel: impl LcdDmaTxChannel<'static>,
         tx_descriptors: &'static mut [DmaDescriptor],
         frequency: Rate,
         fb: &'static FB,
@@ -125,8 +121,6 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         crate::bcm::validate_fb_internal_ram(fb);
 
         let word_size = hub75_pins.word_size();
-
-        let ch_num = channel.channel_num();
 
         let lcd_cam_dev = LcdCam::new(lcd_cam);
 
@@ -141,7 +135,23 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
         };
 
         let i8080 = I8080::new(lcd_cam_dev.lcd, channel, config).map_err(Hub75Error::I8080)?;
-        let i8080 = hub75_pins.apply(i8080);
+        let mut i8080 = hub75_pins.apply(i8080);
+
+        // In circular mode, the LCD_CAM `lcd_trans_done` interrupt never
+        // fires because the DMA chain loops forever and continuous output
+        // mode never ends. Instead we bind the frame-count ISR to the GDMA
+        // TX channel's `out_eof` interrupt, which fires whenever a
+        // descriptor with `suc_eof=1` is encountered, even in a circular
+        // chain.
+        //
+        // Binding the handler unlistens from and clears all DMA TX sources,
+        // so it must happen before the source is enabled. The source is
+        // enabled in `store_circular_state` below, only once the ISR can
+        // service it through the transfer stored there: `send()` starts the
+        // DMA engine, and the first descriptor can complete before the
+        // constructor returns, so enabling the source any earlier could
+        // fire the ISR while it has no transfer to clear the flag through.
+        i8080.set_dma_interrupt_handler(crate::isr::hub75_frame_count_isr);
 
         let mut buf = CircularBcmBuf::new(tx_descriptors, fb);
         let desc_ptr = buf.descriptors_ptr();
@@ -156,75 +166,8 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
 
         crate::isr::store_circular_state(xfer, desc_ptr, desc_count, fb_ptr);
 
-        // In circular mode, the LCD_CAM `lcd_trans_done` interrupt never
-        // fires because the DMA chain loops forever and continuous output
-        // mode never ends. Instead we use the GDMA channel's `out_eof`
-        // interrupt, which fires whenever a descriptor with `suc_eof=1` is
-        // encountered, even in a circular chain.
-        setup_gdma_frame_count_isr(ch_num);
-
         Ok(Self::from_phantom())
     }
-}
-
-// ---------------------------------------------------------------------------
-// GDMA frame-count ISR setup (circular-dma only)
-// ---------------------------------------------------------------------------
-//
-// The LCD_CAM `lcd_trans_done` interrupt never fires in circular DMA mode
-// because continuous output mode never "finishes." We bind the frame-count
-// ISR to the GDMA TX channel's `out_eof` interrupt instead. The channel
-// number is captured from the `GdmaChannelNum` trait before the channel is
-// consumed by the I8080 driver.
-
-#[cfg(feature = "circular-dma")]
-static GDMA_CHANNEL_NUM: core::sync::atomic::AtomicU8 = core::sync::atomic::AtomicU8::new(0);
-
-#[cfg(feature = "circular-dma")]
-fn clear_gdma_out_eof() {
-    let ch = GDMA_CHANNEL_NUM.load(core::sync::atomic::Ordering::Relaxed) as usize;
-    // SAFETY: We only write the interrupt-clear register of the channel we
-    // own, and it's write-1-to-clear, so the write can't disturb other state.
-    unsafe {
-        let dma = esp_hal::peripherals::DMA::steal();
-        dma.register_block()
-            .ch(ch)
-            .out_int()
-            .clr()
-            .write(|w| w.out_eof().clear_bit_by_one());
-    }
-}
-
-#[cfg(feature = "circular-dma")]
-fn setup_gdma_frame_count_isr(ch_num: u8) {
-    use esp_hal::peripherals::Interrupt;
-
-    GDMA_CHANNEL_NUM.store(ch_num, core::sync::atomic::Ordering::Relaxed);
-
-    let interrupt = match ch_num {
-        0 => Interrupt::DMA_OUT_CH0,
-        1 => Interrupt::DMA_OUT_CH1,
-        2 => Interrupt::DMA_OUT_CH2,
-        3 => Interrupt::DMA_OUT_CH3,
-        4 => Interrupt::DMA_OUT_CH4,
-        _ => unreachable!(),
-    };
-
-    esp_hal::interrupt::bind_handler(interrupt, crate::isr::hub75_frame_count_isr);
-
-    // SAFETY: The DMA peripheral is already in use (the transfer is running).
-    // We steal a PAC handle only to enable the `out_eof` interrupt on the
-    // channel we own.
-    unsafe {
-        let dma = esp_hal::peripherals::DMA::steal();
-        dma.register_block()
-            .ch(ch_num as usize)
-            .out_int()
-            .ena()
-            .modify(|_, w| w.out_eof().set_bit());
-    }
-
-    crate::isr::store_clear_interrupt(clear_gdma_out_eof);
 }
 
 impl<FB: crate::framebuffer::FrameBuffer + 'static> Hub75<Blocking, FB> {
@@ -257,7 +200,7 @@ impl<FB: crate::framebuffer::FrameBuffer + 'static> Hub75<Blocking, FB> {
     pub fn new<P: Hub75Pins<'static, Word = FB::Word>>(
         lcd_cam: LCD_CAM<'static>,
         hub75_pins: P,
-        channel: impl LcdDmaTxChannel<'static> + crate::GdmaChannelNum,
+        channel: impl LcdDmaTxChannel<'static>,
         tx_descriptors: &'static mut [DmaDescriptor],
         frequency: Rate,
         fb: &'static FB,
@@ -296,7 +239,7 @@ impl<FB: crate::framebuffer::FrameBuffer + 'static> Hub75<esp_hal::Async, FB> {
     pub fn new_async<P: Hub75Pins<'static, Word = FB::Word>>(
         lcd_cam: LCD_CAM<'static>,
         hub75_pins: P,
-        channel: impl LcdDmaTxChannel<'static> + crate::GdmaChannelNum,
+        channel: impl LcdDmaTxChannel<'static>,
         tx_descriptors: &'static mut [DmaDescriptor],
         frequency: Rate,
         fb: &'static FB,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,53 +429,6 @@ pub trait Hub75Pins<'d, T> {
     fn convert_pins(self) -> (T, AnyPin<'d>);
 }
 
-// ---------------------------------------------------------------------------
-// GDMA channel number trait (ESP32-S3 / C6 / C5)
-// ---------------------------------------------------------------------------
-
-/// Maps a DMA channel singleton to its numeric index so the driver can
-/// configure GDMA interrupts without scanning registers at runtime.
-///
-/// Implemented for every `DMA_CHn` type exported by `esp-hal`. You never
-/// name this trait directly; it is satisfied implicitly when passing a DMA
-/// channel peripheral to [`Hub75::new`].
-#[cfg(any(esp32s3, esp32c6, esp32c5))]
-pub trait GdmaChannelNum {
-    /// Returns the zero-based GDMA channel index (0, 1, 2, …).
-    fn channel_num(&self) -> u8;
-}
-
-#[cfg(any(esp32s3, esp32c6, esp32c5))]
-impl GdmaChannelNum for esp_hal::peripherals::DMA_CH0<'_> {
-    fn channel_num(&self) -> u8 {
-        0
-    }
-}
-#[cfg(any(esp32s3, esp32c6, esp32c5))]
-impl GdmaChannelNum for esp_hal::peripherals::DMA_CH1<'_> {
-    fn channel_num(&self) -> u8 {
-        1
-    }
-}
-#[cfg(any(esp32s3, esp32c6, esp32c5))]
-impl GdmaChannelNum for esp_hal::peripherals::DMA_CH2<'_> {
-    fn channel_num(&self) -> u8 {
-        2
-    }
-}
-#[cfg(esp32s3)]
-impl GdmaChannelNum for esp_hal::peripherals::DMA_CH3<'_> {
-    fn channel_num(&self) -> u8 {
-        3
-    }
-}
-#[cfg(esp32s3)]
-impl GdmaChannelNum for esp_hal::peripherals::DMA_CH4<'_> {
-    fn channel_num(&self) -> u8 {
-        4
-    }
-}
-
 /// Errors returned by the HUB75 driver.
 ///
 /// Wraps the `esp-hal` DMA, buffer, and peripheral errors in one type.

--- a/src/parl_io.rs
+++ b/src/parl_io.rs
@@ -38,6 +38,8 @@ use esp_hal::parl_io::ParlIoDmaChannel;
 use esp_hal::parl_io::ParlIoInterrupt;
 use esp_hal::parl_io::SampleEdge;
 use esp_hal::parl_io::TxConfig;
+#[cfg(esp32c5)]
+use esp_hal::parl_io::TxEofSource;
 use esp_hal::parl_io::TxPins;
 use esp_hal::peripherals::PARL_IO;
 use esp_hal::time::Rate;
@@ -91,21 +93,13 @@ impl<DM: esp_hal::DriverMode, FB: crate::framebuffer::FrameBuffer + 'static> Hub
             .with_sample_edge(sample_edge)
             .with_bit_order(BitPackOrder::Msb);
 
+        // On the C5 the TX EOF must come from the DMA channel rather than the
+        // peripheral's bit-length counter, or the refresh-loop ISR never fires.
+        #[cfg(esp32c5)]
+        let config = config.with_eof_source(TxEofSource::DmaEof);
+
         let clk_pin = ClkOutPin::new(clock_pin);
         let parl_io_tx = parl_io_dev.tx.with_config(pins, clk_pin, config)?;
-
-        // SAFETY: The driver above owns the PARL_IO peripheral. We steal it
-        // only to set the `tx_eof_gen_sel` bit, so the DMA EOF
-        // signal comes from the GDMA channel rather than the peripheral's
-        // byte counter; esp-hal doesn't expose this register. The ISR isn't
-        // active yet, so no data race.
-        #[cfg(esp32c5)]
-        unsafe {
-            esp_hal::peripherals::PARL_IO::steal()
-                .register_block()
-                .tx_genrl_cfg()
-                .modify(|_, w| w.tx_eof_gen_sel().set_bit());
-        }
 
         let buf = BcmBuf::new(tx_descriptors);
         crate::isr::init_isr_state(parl_io_tx, buf);


### PR DESCRIPTION
This mainly applies to 'circular-dma':
- [x] esp32: i2s_parallel
- [x] esp32s3: lcd_cam
- [ ] esp32c5: parl_io

This uses unreleased esp-hal from the main branch.